### PR TITLE
Stream entries out to kafka

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,9 +2,9 @@ group 'mint'
 
 //noinspection GroovyAssignabilityCheck
 dependencies {
-    compile rabbitMQ, postgresClient, jOptSimple, json, javaslang
+    compile javaslang, jOptSimple, json, kafka, rabbitMQ, postgresClient
 
-    testCompile junit, mockito
+    testCompile junit, kafkaTest, mockito, zkTest
 }
 
 

--- a/app/src/main/java/uk/gov/store/DataStore.java
+++ b/app/src/main/java/uk/gov/store/DataStore.java
@@ -2,4 +2,6 @@ package uk.gov.store;
 
 public interface DataStore {
     void add(byte[] message);
+
+    void close() throws Exception;
 }

--- a/app/src/main/java/uk/gov/store/LocalDataStoreApplication.java
+++ b/app/src/main/java/uk/gov/store/LocalDataStoreApplication.java
@@ -4,13 +4,17 @@ import uk.gov.integration.DataStoreApplication;
 
 public class LocalDataStoreApplication implements DataStoreApplication {
     private DataStore dataStore;
+    private LogStream logStream;
 
-    public LocalDataStoreApplication(DataStore dataStore) {
+    public LocalDataStoreApplication(DataStore dataStore, LogStream logStream) {
         this.dataStore = dataStore;
+        this.logStream = logStream;
     }
 
     @Override
     public void add(byte[] message) {
+        // TODO: this could be bad if postgres succeeds and kafka fails. we need to think about this at some point.
         dataStore.add(message);
+        logStream.send(message);
     }
 }

--- a/app/src/main/java/uk/gov/store/LogStream.java
+++ b/app/src/main/java/uk/gov/store/LogStream.java
@@ -1,0 +1,29 @@
+package uk.gov.store;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.io.IOException;
+
+public class LogStream {
+    private final Producer<String, byte[]> producer;
+    public static final String TOPIC_NAME = "register";
+
+    public LogStream(String bootstrapServers) {
+        this.producer = new KafkaProducer<>(ImmutableMap.of(
+                "bootstrap.servers", bootstrapServers,
+                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
+                "value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer"
+        ));
+    }
+
+    public void send(byte[] message) {
+        producer.send(new ProducerRecord<>(TOPIC_NAME, "primaryKey", message));
+    }
+
+    public void close() throws IOException {
+        producer.close();
+    }
+}

--- a/app/src/main/java/uk/gov/store/PostgresDataStore.java
+++ b/app/src/main/java/uk/gov/store/PostgresDataStore.java
@@ -32,4 +32,9 @@ public class PostgresDataStore implements DataStore {
         }
 
     }
+
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
 }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+kafka.bootstrap.servers=localhost:9092
+
 rabbitmq.connection.string=amqp://127.0.0.1:5672
 rabbitmq.exchange=localhost-register-exchange
 rabbitmq.queue=localhost-register-queue

--- a/app/src/test/java/uk/gov/functional/FunctionalTest.java
+++ b/app/src/test/java/uk/gov/functional/FunctionalTest.java
@@ -9,27 +9,30 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.Application;
 
-import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class FunctionalTest {
-    private String rabbitMQConnectionString;
     private String exchange;
     private String routingKey;
     private String queue;
     private java.sql.Connection pgConnection;
     private Application application;
+    private TestKafkaCluster testKafkaCluster;
+    private Channel channel;
 
     @Before
-    public void setup() throws SQLException, IOException {
+    public void setup() throws Exception {
         Properties properties = new Properties();
         String configFilename = FunctionalTest.class.getResource("/test-application.properties").getFile();
         InputStream resourceAsStream = FunctionalTest.class.getResourceAsStream("/test-application.properties");
@@ -38,10 +41,19 @@ public class FunctionalTest {
         exchange = properties.getProperty("rabbitmq.exchange");
         routingKey = properties.getProperty("rabbitmq.exchange.routing.key");
         queue = properties.getProperty("rabbitmq.queue");
-        rabbitMQConnectionString = properties.getProperty("rabbitmq.connection.string");
+        String rabbitMQConnectionString = properties.getProperty("rabbitmq.connection.string");
 
         pgConnection = DriverManager.getConnection(properties.getProperty("postgres.connection.string"));
+
+        ConnectionFactory factory = new ConnectionFactory();
+        factory.setUri(rabbitMQConnectionString);
+        Connection conn = factory.newConnection();
+        channel = conn.createChannel();
+
         cleanDatabase();
+        cleanQueue();
+
+        testKafkaCluster = new TestKafkaCluster(6000); // must match test-application.properties
 
         application = new Application("config.file=" + configFilename);
         application.startup();
@@ -50,23 +62,21 @@ public class FunctionalTest {
     @After
     public void tearDown() throws Exception {
         application.shutdown();
+        testKafkaCluster.stop();
     }
 
     @Test
     public void checkMessageIsConsumedAndStoredInDatabase() throws Exception {
-
-        ConnectionFactory factory = new ConnectionFactory();
-        factory.setUri(rabbitMQConnectionString);
-        Connection conn = factory.newConnection();
-        Channel channel = conn.createChannel();
-
-        AMQP.Queue.BindOk bindOk = channel.queueBind(queue, exchange, routingKey);
 
         byte[] message = String.valueOf(System.currentTimeMillis()).getBytes();
         channel.basicPublish(exchange, routingKey, new AMQP.BasicProperties(), message);
 
         waitForMessageToBeConsumed();
         assertThat(tableRecord(), is(message));
+
+        List<String> messages = testKafkaCluster.readMessages("register", 1);
+        String messageString = new String(message, Charset.forName("UTF-8"));
+        assertThat(messages, is(Collections.singletonList(messageString)));
     }
 
     private byte[] tableRecord() throws SQLException {
@@ -79,6 +89,10 @@ public class FunctionalTest {
 
     private void waitForMessageToBeConsumed() throws InterruptedException {
         Thread.sleep(100);
+    }
+
+    private void cleanQueue() throws Exception {
+        channel.queuePurge(queue);
     }
 
     private void cleanDatabase() throws SQLException {

--- a/app/src/test/java/uk/gov/functional/TestKafkaCluster.java
+++ b/app/src/test/java/uk/gov/functional/TestKafkaCluster.java
@@ -1,0 +1,95 @@
+package uk.gov.functional;
+
+import kafka.consumer.Consumer;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.ConsumerIterator;
+import kafka.consumer.KafkaStream;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.serializer.StringDecoder;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServerStartable;
+import kafka.utils.TestUtils;
+import kafka.utils.VerifiableProperties;
+import org.apache.curator.test.TestingServer;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Copied from <a href="https://cwiki.apache.org/confluence/display/KAFKA/FAQ#FAQ-Unittesting">kafka FAQ</a>
+ */
+public class TestKafkaCluster {
+
+    private final TestingServer zkServer;
+    private final KafkaServerStartable kafkaServer;
+
+    public TestKafkaCluster(int zkPort) throws Exception {
+        zkServer = new TestingServer(zkPort);
+        KafkaConfig config = getKafkaConfig(zkServer.getConnectString());
+        kafkaServer = new KafkaServerStartable(config);
+        kafkaServer.startup();
+    }
+
+    private KafkaConfig getKafkaConfig(String zkConnectString) {
+        Iterator<Properties> propsIterator = TestUtils.createBrokerConfigs(1, false).iterator();
+        assert propsIterator.hasNext();
+        Properties props = propsIterator.next();
+        assert props.containsKey("zookeeper.connect");
+        props.put("zookeeper.connect", zkConnectString);
+        props.put("port","6001");
+        System.out.println("kafka props: " + props);
+        return new KafkaConfig(props);
+    }
+
+    public void stop() throws IOException {
+        kafkaServer.shutdown();
+        zkServer.stop();
+    }
+
+    public List<String> readMessages(String topicName, int expectedMessages) throws TimeoutException {
+        ExecutorService singleThread = Executors.newSingleThreadExecutor();
+        Properties consumerProperties = new Properties();
+        consumerProperties.put("zookeeper.connect", zkServer.getConnectString());
+        consumerProperties.put("group.id", "10");
+        consumerProperties.put("socket.timeout.ms", "500");
+        consumerProperties.put("consumer.id", "test");
+        consumerProperties.put("auto.offset.reset", "smallest");
+        ConsumerConnector javaConsumerConnector = Consumer.createJavaConsumerConnector(new ConsumerConfig(consumerProperties));
+        StringDecoder stringDecoder = new StringDecoder(new VerifiableProperties(new Properties()));
+        Map<String, Integer> topicMap = new HashMap<>();
+        topicMap.put(topicName, 1);
+        Map<String, List<KafkaStream<String, String>>> events = javaConsumerConnector.createMessageStreams(topicMap, stringDecoder, stringDecoder);
+        List<KafkaStream<String, String>> events1 = events.get(topicName);
+        KafkaStream<String, String> kafkaStreams = events1.get(0);
+
+        Future<List<String>> submit = singleThread.submit(() -> {
+            List<String> messages = new ArrayList<>();
+            ConsumerIterator<String, String> iterator = kafkaStreams.iterator();
+            while (messages.size() != expectedMessages && iterator.hasNext()) {
+                String message = iterator.next().message();
+                messages.add(message);
+            }
+            return messages;
+        });
+
+        try {
+            return submit.get(3, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new TimeoutException("Timed out waiting for messages");
+        } finally {
+            singleThread.shutdown();
+            javaConsumerConnector.shutdown();
+        }
+    }
+}

--- a/app/src/test/resources/test-application.properties
+++ b/app/src/test/resources/test-application.properties
@@ -1,8 +1,10 @@
+kafka.bootstrap.servers=localhost:6001
+
+postgres.connection.string=jdbc:postgresql://localhost:5432/ft_mint
+
 rabbitmq.connection.string=amqp://127.0.0.1:5672
 rabbitmq.exchange=test-register-exchange
 rabbitmq.queue=test-register-queue
 rabbitmq.exchange.routing.key=test-register-queue-routing-key
-
-postgres.connection.string=jdbc:postgresql://localhost:5432/ft_mint
 
 store.name=functional_tests

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,16 +1,20 @@
 ext{
-	rabbitMQ = 'com.rabbitmq:amqp-client:3.5.3'
-	postgresClient ='org.postgresql:postgresql:9.4-1200-jdbc41'
-	jOptSimple = 'net.sf.jopt-simple:jopt-simple:4.8'
-	logback = 'ch.qos.logback:logback-core:1.1.3'
-	slf4j = 'org.slf4j:slf4j-api:1.7.12'
 	javaslang = 'com.javaslang:javaslang:1.2.2'
+	jOptSimple = 'net.sf.jopt-simple:jopt-simple:4.8'
 	json = [
 		'com.fasterxml.jackson.core:jackson-core:2.5.4',
 		'com.fasterxml.jackson.core:jackson-databind:2.5.4',
 		'com.fasterxml.jackson.core:jackson-annotations:2.5.4'
 	]
+	kafka = 'org.apache.kafka:kafka-clients:0.8.2.1'
+	logback = 'ch.qos.logback:logback-core:1.1.3'
+	rabbitMQ = 'com.rabbitmq:amqp-client:3.5.3'
+	postgresClient ='org.postgresql:postgresql:9.4-1200-jdbc41'
+	slf4j = 'org.slf4j:slf4j-api:1.7.12'
+
 	//test-dependencies
 	junit = 'junit:junit:4.12'
+	kafkaTest = ['org.apache.kafka:kafka_2.10:0.8.2.1','org.apache.kafka:kafka_2.10:0.8.2.1:test']
 	mockito = 'org.mockito:mockito-core:1.9.5'
+	zkTest = 'org.apache.curator:curator-test:2.8.0'
 }


### PR DESCRIPTION
In order to communicate with the various indexes that will want to
consume a register, we'd like to use kafka.  This change causes the mint
to write all incoming messages to kafka as well as postgres.

The FunctionalTest is modified to spin up a JVM-local kafka (plus
zookeeper) instance and ensure that the message is written to both
postgres and kafka.

No thought has been put into error handling.  In particular, if the
postgres write succeeds but the kafka write fails, we could end up in an
inconsistent state between the data store and the kafka stream.
