### PR TITLE
validate & canonicalize entries as JSON

### DIFF
--- a/app/src/main/java/uk/gov/mint/MessageHandler.java
+++ b/app/src/main/java/uk/gov/mint/MessageHandler.java
@@ -1,8 +1,11 @@
 package uk.gov.mint;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
@@ -10,6 +13,8 @@ import com.rabbitmq.client.Envelope;
 import uk.gov.integration.DataStoreApplication;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 
 class MessageHandler extends DefaultConsumer {
 
@@ -22,12 +27,15 @@ class MessageHandler extends DefaultConsumer {
         this.channel = channel;
         this.dataStoreApplication = dataStoreApplication;
         objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
     }
 
     @Override
     public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        JsonNode jsonNode;
         try {
-            objectMapper.readValue(body, JsonNode.class);
+            jsonNode = objectMapper.readValue(body, JsonNode.class);
         } catch (JsonParseException e) {
             // ACK message as we know it's unprocessable
             channel.basicAck(envelope.getDeliveryTag(), false);
@@ -35,7 +43,15 @@ class MessageHandler extends DefaultConsumer {
             return;
         }
 
-        dataStoreApplication.add(body);
+        dataStoreApplication.add(canonicalize(jsonNode));
         channel.basicAck(envelope.getDeliveryTag(), false);
+    }
+
+    private byte[] canonicalize(JsonNode jsonNode) throws JsonProcessingException {
+        // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
+        Object obj = objectMapper.treeToValue(jsonNode, Object.class);
+        Writer w = new StringWriter();
+        // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
+        return objectMapper.writeValueAsString(obj).getBytes();
     }
 }

--- a/app/src/main/java/uk/gov/mint/MessageHandler.java
+++ b/app/src/main/java/uk/gov/mint/MessageHandler.java
@@ -1,5 +1,8 @@
 package uk.gov.mint;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
@@ -12,15 +15,26 @@ class MessageHandler extends DefaultConsumer {
 
     private final Channel channel;
     private final DataStoreApplication dataStoreApplication;
+    private final ObjectMapper objectMapper;
 
     public MessageHandler(Channel channel, DataStoreApplication dataStoreApplication) {
         super(channel);
         this.channel = channel;
         this.dataStoreApplication = dataStoreApplication;
+        objectMapper = new ObjectMapper();
     }
 
     @Override
     public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+        try {
+            objectMapper.readValue(body, JsonNode.class);
+        } catch (JsonParseException e) {
+            // ACK message as we know it's unprocessable
+            channel.basicAck(envelope.getDeliveryTag(), false);
+            // FIXME: should report this failure somewhere
+            return;
+        }
+
         dataStoreApplication.add(body);
         channel.basicAck(envelope.getDeliveryTag(), false);
     }

--- a/app/src/test/java/uk/gov/functional/FunctionalTest.java
+++ b/app/src/test/java/uk/gov/functional/FunctionalTest.java
@@ -67,14 +67,14 @@ public class FunctionalTest {
     @Test
     public void checkMessageIsConsumedAndStoredInDatabase() throws Exception {
 
-        byte[] message = String.valueOf(System.currentTimeMillis()).getBytes();
+        String messageString = String.format("{\"time\":%s}", String.valueOf(System.currentTimeMillis()));
+        byte[] message = messageString.getBytes();
         connection.createChannel().basicPublish(exchange, routingKey, new AMQP.BasicProperties(), message);
 
         waitForMessageToBeConsumed();
         assertThat(tableRecord(), is(message));
 
         List<String> messages = testKafkaCluster.readMessages("register", 1);
-        String messageString = new String(message, Charset.forName("UTF-8"));
         assertThat(messages, is(Collections.singletonList(messageString)));
     }
 
@@ -87,7 +87,7 @@ public class FunctionalTest {
     }
 
     private void waitForMessageToBeConsumed() throws InterruptedException {
-        Thread.sleep(100);
+        Thread.sleep(500);
     }
 
     private void cleanQueue() throws Exception {

--- a/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
+++ b/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
@@ -1,0 +1,41 @@
+package uk.gov.mint;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Envelope;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.integration.DataStoreApplication;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MessageHandlerTest {
+
+    private MessageHandler messageHandler;
+
+    @Mock
+    private Channel channel;
+    @Mock
+    private DataStoreApplication dataStore;
+
+    @Before
+    public void setUp() throws Exception {
+        messageHandler = new MessageHandler(channel, dataStore);
+    }
+
+    @Test
+    public void shouldAcceptJsonEntry() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"bar\"}".getBytes();
+        Envelope mock = mock(Envelope.class);
+        when(mock.getDeliveryTag()).thenReturn(52L);
+        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+
+        verify(dataStore).add(jsonBytes);
+        verify(channel).basicAck(52L, false);
+    }
+}

--- a/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
+++ b/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
@@ -11,6 +11,7 @@ import uk.gov.integration.DataStoreApplication;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,5 +38,35 @@ public class MessageHandlerTest {
 
         verify(dataStore).add(jsonBytes);
         verify(channel).basicAck(52L, false);
+    }
+
+    @Test
+    public void shouldNotAcceptIllFormedJsonEntry() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"bar\"".getBytes();
+
+        Envelope mock = mock(Envelope.class);
+        when(mock.getDeliveryTag()).thenReturn(52L);
+
+        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+
+        // We should ack the message as it's ill-formed
+        // TODO: need some sort of dead letter queue
+        verify(channel).basicAck(52L, false);
+
+        verifyNoMoreInteractions(channel, dataStore);
+    }
+
+    @Test
+    public void shouldNotAcceptJsonEntryWithUnescapedQuoteMarks() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"\"\"}".getBytes();
+        Envelope mock = mock(Envelope.class);
+        when(mock.getDeliveryTag()).thenReturn(52L);
+        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+
+        // We should ack the message as it's ill-formed
+        // TODO: need some sort of dead letter queue
+        verify(channel).basicAck(52L, false);
+
+        verifyNoMoreInteractions(channel, dataStore);
     }
 }

--- a/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
+++ b/app/src/test/java/uk/gov/mint/MessageHandlerTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.integration.DataStoreApplication;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -17,41 +16,40 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MessageHandlerTest {
 
+    public static final long DELIVERY_TAG = 52L;
     private MessageHandler messageHandler;
 
     @Mock
     private Channel channel;
     @Mock
     private DataStoreApplication dataStore;
+    @Mock
+    private Envelope envelope;
 
     @Before
     public void setUp() throws Exception {
         messageHandler = new MessageHandler(channel, dataStore);
+        when(envelope.getDeliveryTag()).thenReturn(DELIVERY_TAG);
     }
 
     @Test
     public void shouldAcceptJsonEntry() throws Exception {
         byte[] jsonBytes = "{\"foo\":\"bar\"}".getBytes();
-        Envelope mock = mock(Envelope.class);
-        when(mock.getDeliveryTag()).thenReturn(52L);
-        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+        messageHandler.handleDelivery(null, envelope, null, jsonBytes);
 
         verify(dataStore).add(jsonBytes);
-        verify(channel).basicAck(52L, false);
+        verify(channel).basicAck(DELIVERY_TAG, false);
     }
 
     @Test
     public void shouldNotAcceptIllFormedJsonEntry() throws Exception {
         byte[] jsonBytes = "{\"foo\":\"bar\"".getBytes();
 
-        Envelope mock = mock(Envelope.class);
-        when(mock.getDeliveryTag()).thenReturn(52L);
-
-        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+        messageHandler.handleDelivery(null, envelope, null, jsonBytes);
 
         // We should ack the message as it's ill-formed
         // TODO: need some sort of dead letter queue
-        verify(channel).basicAck(52L, false);
+        verify(channel).basicAck(DELIVERY_TAG, false);
 
         verifyNoMoreInteractions(channel, dataStore);
     }
@@ -59,14 +57,70 @@ public class MessageHandlerTest {
     @Test
     public void shouldNotAcceptJsonEntryWithUnescapedQuoteMarks() throws Exception {
         byte[] jsonBytes = "{\"foo\":\"\"\"}".getBytes();
-        Envelope mock = mock(Envelope.class);
-        when(mock.getDeliveryTag()).thenReturn(52L);
-        messageHandler.handleDelivery(null, mock, null, jsonBytes);
+
+        messageHandler.handleDelivery(null, envelope, null, jsonBytes);
 
         // We should ack the message as it's ill-formed
         // TODO: need some sort of dead letter queue
-        verify(channel).basicAck(52L, false);
+        verify(channel).basicAck(DELIVERY_TAG, false);
 
         verifyNoMoreInteractions(channel, dataStore);
+    }
+
+    @Test
+    public void shouldTransformJsonToCanonicalMapFieldOrder() throws Exception {
+        byte[] originalBytes = "{\"bbb\":5,\"ccc\":\"foo\",\"aaa\":\"bar\"}".getBytes();
+        byte[] sortedBytes = "{\"aaa\":\"bar\",\"bbb\":5,\"ccc\":\"foo\"}".getBytes();
+
+        messageHandler.handleDelivery(null, envelope, null, originalBytes);
+
+        verify(dataStore).add(sortedBytes);
+        verify(channel).basicAck(DELIVERY_TAG, false);
+    }
+
+    @Test
+    public void shouldStripWhitespaceFromJson() throws Exception {
+        byte[] originalBytes = "{   \"  foo  \" \t\n : \r \"   \"}".getBytes();
+        byte[] sortedBytes = "{\"  foo  \":\"   \"}".getBytes();
+
+        messageHandler.handleDelivery(null, envelope, null, originalBytes);
+
+        verify(dataStore).add(sortedBytes);
+        verify(channel).basicAck(DELIVERY_TAG, false);
+    }
+
+    @Test
+    public void shouldTransformSimpleUnicodeEscapesToUnescapedValues() throws Exception {
+        byte[] originalBytes = "{\"\\u0066\\u006f\\u006f\":\"bar\\n\"}".getBytes();
+        byte[] canonicalBytes = "{\"foo\":\"bar\\n\"}".getBytes();
+
+        messageHandler.handleDelivery(null, envelope, null, originalBytes);
+
+        verify(dataStore).add(canonicalBytes);
+        verify(channel).basicAck(DELIVERY_TAG, false);
+    }
+
+    @Test
+    public void shouldTransformComplexUnicodeEscapesToUnescapedValues() throws Exception {
+        // uses MUSICAL SYMBOL G CLEF (U+1D11E) as a non-BMP character
+        byte[] originalBytes = "{\"g-clef\":\"\\uD834\\uDD1E\"}".getBytes(); // note this is unicode escaped in the JSON
+        byte[] canonicalBytes = String.format("{\"g-clef\":\"%s\"}", new String(Character.toChars(0x0001D11E))).getBytes();
+
+        messageHandler.handleDelivery(null, envelope, null, originalBytes);
+
+        verify(dataStore).add(canonicalBytes);
+        verify(channel).basicAck(DELIVERY_TAG, false);
+    }
+
+    @Test
+    public void shouldTransformComplexUnicodeEscapesInKeysToUnescapedValues() throws Exception {
+        // uses MUSICAL SYMBOL G CLEF (U+1D11E) as a non-BMP character
+        byte[] originalBytes = "{\"\\uD834\\uDD1E\":\"g-clef\"}".getBytes(); // note this is unicode escaped in the JSON
+        byte[] canonicalBytes = String.format("{\"%s\":\"g-clef\"}", new String(Character.toChars(0x0001D11E))).getBytes();
+
+        messageHandler.handleDelivery(null, envelope, null, originalBytes);
+
+        verify(dataStore).add(canonicalBytes);
+        verify(channel).basicAck(DELIVERY_TAG, false);
     }
 }


### PR DESCRIPTION
This PR rejects messages which are not well-formed JSON.  It then makes the mint transform json messages into a canonical form:
- whitespace is stripped
- map keys are sorted
- unicode escape sequences are _not_ used

It makes no attempt to reduce unicode strings themselves to a canonical form such as NFC.

See individual commit messages for further context.
