### PR TITLE
extract CanonicalJsonMapper class

### DIFF
--- a/app/src/main/java/uk/gov/mint/CanonicalJsonMapper.java
+++ b/app/src/main/java/uk/gov/mint/CanonicalJsonMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.mint;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.IOException;
+
+public class CanonicalJsonMapper {
+    private final ObjectMapper objectMapper;
+
+    public CanonicalJsonMapper() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+    }
+
+    public JsonNode readFromBytes(byte[] body) throws IOException {
+        return objectMapper.readValue(body, JsonNode.class);
+    }
+
+    public byte[] writeToBytes(JsonNode jsonNode) throws JsonProcessingException {
+        // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
+        Object obj = objectMapper.treeToValue(jsonNode, Object.class);
+        // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
+        // our canonical form requires raw unescaped unicode, so we need this version
+        return objectMapper.writeValueAsString(obj).getBytes();
+    }
+}

--- a/app/src/main/java/uk/gov/mint/MessageHandler.java
+++ b/app/src/main/java/uk/gov/mint/MessageHandler.java
@@ -1,11 +1,7 @@
 package uk.gov.mint;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
@@ -18,22 +14,20 @@ class MessageHandler extends DefaultConsumer {
 
     private final Channel channel;
     private final DataStoreApplication dataStoreApplication;
-    private final ObjectMapper objectMapper;
+    private final CanonicalJsonMapper canonicalJsonMapper;
 
-    public MessageHandler(Channel channel, DataStoreApplication dataStoreApplication) {
+    public MessageHandler(Channel channel, DataStoreApplication dataStoreApplication, CanonicalJsonMapper canonicalJsonMapper) {
         super(channel);
         this.channel = channel;
         this.dataStoreApplication = dataStoreApplication;
-        objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-        objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
+        this.canonicalJsonMapper = canonicalJsonMapper;
     }
 
     @Override
     public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
         JsonNode jsonNode;
         try {
-            jsonNode = objectMapper.readValue(body, JsonNode.class);
+            jsonNode = canonicalJsonMapper.readFromBytes(body);
         } catch (JsonParseException e) {
             // ACK message as we know it's unprocessable
             channel.basicAck(envelope.getDeliveryTag(), false);
@@ -41,15 +35,7 @@ class MessageHandler extends DefaultConsumer {
             return;
         }
 
-        dataStoreApplication.add(canonicalize(jsonNode));
+        dataStoreApplication.add(canonicalJsonMapper.writeToBytes(jsonNode));
         channel.basicAck(envelope.getDeliveryTag(), false);
-    }
-
-    private byte[] canonicalize(JsonNode jsonNode) throws JsonProcessingException {
-        // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
-        Object obj = objectMapper.treeToValue(jsonNode, Object.class);
-        // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
-        // our canonical form requires raw unescaped unicode, so we need this version
-        return objectMapper.writeValueAsString(obj).getBytes();
     }
 }

--- a/app/src/main/java/uk/gov/mint/RabbitMQConnector.java
+++ b/app/src/main/java/uk/gov/mint/RabbitMQConnector.java
@@ -32,7 +32,7 @@ public class RabbitMQConnector {
             AMQP.Queue.DeclareOk declareQueue = channel.queueDeclare(queue, true, false, false, Collections.<String, Object>emptyMap());
             AMQP.Queue.BindOk bindOk = channel.queueBind(queue, exchange, routingKey);
 
-            Consumer consumer = new MessageHandler(channel, dataStoreApplication);
+            Consumer consumer = new MessageHandler(channel, dataStoreApplication, new CanonicalJsonMapper());
             channel.basicConsume(queue, consumer);
         } catch (Throwable t) {
             throw new RuntimeException(t);

--- a/app/src/test/java/uk/gov/mint/CanonicalJsonMapperTest.java
+++ b/app/src/test/java/uk/gov/mint/CanonicalJsonMapperTest.java
@@ -1,0 +1,86 @@
+package uk.gov.mint;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CanonicalJsonMapperTest {
+    public final CanonicalJsonMapper mapper = new CanonicalJsonMapper();
+
+    @Test
+    public void shouldAcceptJson() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"bar\"}".getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(jsonBytes));
+        
+        assertThat(canonicalBytes, equalTo(jsonBytes));
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void shouldNotAcceptJsonWithUnbalancedBraces() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"bar\"".getBytes();
+
+        mapper.readFromBytes(jsonBytes);
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void shouldNotAcceptJsonWithUnescapedQuoteMarks() throws Exception {
+        byte[] jsonBytes = "{\"foo\":\"\"\"}".getBytes();
+
+        mapper.readFromBytes(jsonBytes);
+    }
+
+    @Test
+    public void shouldTransformJsonToCanonicalMapFieldOrder() throws Exception {
+        byte[] originalBytes = "{\"bbb\":5,\"ccc\":\"foo\",\"aaa\":\"bar\"}".getBytes();
+        byte[] sortedBytes = "{\"aaa\":\"bar\",\"bbb\":5,\"ccc\":\"foo\"}".getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(originalBytes));
+
+        assertThat(canonicalBytes, equalTo(sortedBytes));
+    }
+
+    @Test
+    public void shouldStripWhitespaceFromJson() throws Exception {
+        byte[] originalBytes = "{   \"  foo  \" \t\n : \r \"   \"}".getBytes();
+        byte[] strippedBytes = "{\"  foo  \":\"   \"}".getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(originalBytes));
+
+        assertThat(canonicalBytes, equalTo(strippedBytes));
+    }
+
+    @Test
+    public void shouldTransformSimpleUnicodeEscapesToUnescapedValues() throws Exception {
+        byte[] originalBytes = "{\"\\u0066\\u006f\\u006f\":\"bar\\n\"}".getBytes();
+        byte[] unescapedBytes = "{\"foo\":\"bar\\n\"}".getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(originalBytes));
+
+        assertThat(canonicalBytes, equalTo(unescapedBytes));
+    }
+
+    @Test
+    public void shouldTransformComplexUnicodeEscapesToUnescapedValues() throws Exception {
+        // uses MUSICAL SYMBOL G CLEF (U+1D11E) as a non-BMP character
+        byte[] originalBytes = "{\"g-clef\":\"\\uD834\\uDD1E\"}".getBytes(); // note this is unicode escaped in the JSON
+        byte[] unescapedBytes = String.format("{\"g-clef\":\"%s\"}", new String(Character.toChars(0x0001D11E))).getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(originalBytes));
+
+        assertThat(canonicalBytes, equalTo(unescapedBytes));
+    }
+
+    @Test
+    public void shouldTransformComplexUnicodeEscapesInKeysToUnescapedValues() throws Exception {
+        // uses MUSICAL SYMBOL G CLEF (U+1D11E) as a non-BMP character
+        byte[] originalBytes = "{\"\\uD834\\uDD1E\":\"g-clef\"}".getBytes(); // note this is unicode escaped in the JSON
+        byte[] unescapedBytes = String.format("{\"%s\":\"g-clef\"}", new String(Character.toChars(0x0001D11E))).getBytes();
+
+        byte[] canonicalBytes = mapper.writeToBytes(mapper.readFromBytes(originalBytes));
+
+        assertThat(canonicalBytes, equalTo(unescapedBytes));
+    }
+}


### PR DESCRIPTION
The MessageHandler had at least two responsibilities: canonicalizing
JSON, and deciding whether to pass on messages to the
DataStoreApplication or not.  This extracts a CanonicalJsonMapper
class.  Hopefully the tests read better this way too.
