### PR TITLE
Remove dual writes problem from kafka sending

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ group 'mint'
 
 //noinspection GroovyAssignabilityCheck
 dependencies {
-    compile javaslang, jOptSimple, json, kafka, rabbitMQ, postgresClient
+    compile javaslang, jdbi, jOptSimple, json, kafka, rabbitMQ, postgresClient
 
     testCompile junit, kafkaTest, mockito, zkTest
 }

--- a/app/src/main/java/uk/gov/Application.java
+++ b/app/src/main/java/uk/gov/Application.java
@@ -39,7 +39,7 @@ public class Application {
 
         String kafkaString = configuration.getProperty("kafka.bootstrap.servers");
         consoleLog("Connecting to Kafka: " + kafkaString);
-        logStream = new LogStream(kafkaString);
+        logStream = new LogStream(pgConnectionString, storeName, kafkaString);
 
         mqConnector = new RabbitMQConnector(new LocalDataStoreApplication(dataStore, logStream));
         mqConnector.connect(configuration);

--- a/app/src/main/java/uk/gov/Application.java
+++ b/app/src/main/java/uk/gov/Application.java
@@ -1,12 +1,17 @@
 package uk.gov;
 
 import com.google.common.base.Strings;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.skife.jdbi.v2.DBI;
 import uk.gov.mint.RabbitMQConnector;
 import uk.gov.store.DataStore;
+import uk.gov.store.EntriesQueryDAO;
+import uk.gov.store.HighWaterMarkDAO;
 import uk.gov.store.LocalDataStoreApplication;
 import uk.gov.store.LogStream;
 import uk.gov.store.PostgresDataStore;
 
+import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -33,18 +38,27 @@ public class Application {
 
     public void startup() {
         String pgConnectionString = configuration.getProperty("postgres.connection.string");
-        String storeName = configuration.getProperty("store.name");
         consoleLog("Connecting to Postgres database: " + pgConnectionString);
-        dataStore = new PostgresDataStore(pgConnectionString, storeName);
+        DataSource ds = createDataSource(configuration.getProperty("postgres.database"));
+        DBI dbi = new DBI(ds);
+        HighWaterMarkDAO highWaterMarkDAO = dbi.onDemand(HighWaterMarkDAO.class);
+        EntriesQueryDAO entriesQueryDAO = dbi.onDemand(EntriesQueryDAO.class);
+        dataStore = new PostgresDataStore(pgConnectionString);
 
         String kafkaString = configuration.getProperty("kafka.bootstrap.servers");
         consoleLog("Connecting to Kafka: " + kafkaString);
-        logStream = new LogStream(pgConnectionString, storeName, kafkaString);
+        logStream = new LogStream(kafkaString, highWaterMarkDAO, entriesQueryDAO);
 
         mqConnector = new RabbitMQConnector(new LocalDataStoreApplication(dataStore, logStream));
         mqConnector.connect(configuration);
 
         consoleLog("Application started...");
+    }
+
+    private DataSource createDataSource(String databaseName) {
+        PGSimpleDataSource source = new PGSimpleDataSource();
+        source.setDatabaseName(databaseName);
+        return source;
     }
 
     public void shutdown() throws Exception {

--- a/app/src/main/java/uk/gov/store/EntriesQueryDAO.java
+++ b/app/src/main/java/uk/gov/store/EntriesQueryDAO.java
@@ -1,0 +1,17 @@
+package uk.gov.store;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+
+import java.util.Iterator;
+
+@RegisterMapper(IndexedEntryMapper.class)
+public interface EntriesQueryDAO {
+    String tableName = "entries";
+
+    @SqlQuery("SELECT ID, ENTRY FROM " + tableName + " WHERE ID > :high_water_mark ORDER BY ID")
+    Iterator<IndexedEntry> getEntriesSince(@Bind("high_water_mark") int highWaterMark);
+
+    void close();
+}

--- a/app/src/main/java/uk/gov/store/HighWaterMarkDAO.java
+++ b/app/src/main/java/uk/gov/store/HighWaterMarkDAO.java
@@ -1,0 +1,20 @@
+package uk.gov.store;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+public interface HighWaterMarkDAO {
+    String tableName = "streamed_entries";
+
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + tableName + " (ID INTEGER PRIMARY KEY, TIME TIMESTAMP)")
+    void ensureTableExists();
+
+    @SqlUpdate("INSERT INTO " + tableName + " VALUES(:high_water_mark, now())")
+    void updateHighWaterMark(@Bind("high_water_mark") int newHighWaterMark);
+
+    @SqlQuery("SELECT ID FROM " + tableName + " ORDER BY ID DESC LIMIT 1")
+    int getCurrentHighWaterMark();
+
+    void close();
+}

--- a/app/src/main/java/uk/gov/store/IndexedEntry.java
+++ b/app/src/main/java/uk/gov/store/IndexedEntry.java
@@ -1,0 +1,19 @@
+package uk.gov.store;
+
+public class IndexedEntry {
+    private final byte[] entry;
+    private final int serial;
+
+    public IndexedEntry(int serial, byte[] entry) {
+        this.entry = entry;
+        this.serial = serial;
+    }
+
+    public byte[] getEntry() {
+        return entry;
+    }
+
+    public int getSerial() {
+        return serial;
+    }
+}

--- a/app/src/main/java/uk/gov/store/IndexedEntryMapper.java
+++ b/app/src/main/java/uk/gov/store/IndexedEntryMapper.java
@@ -1,0 +1,14 @@
+package uk.gov.store;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class IndexedEntryMapper implements ResultSetMapper<IndexedEntry> {
+    @Override
+    public IndexedEntry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        return new IndexedEntry(r.getInt("ID"), r.getBytes("ENTRY"));
+    }
+}

--- a/app/src/main/java/uk/gov/store/LocalDataStoreApplication.java
+++ b/app/src/main/java/uk/gov/store/LocalDataStoreApplication.java
@@ -13,8 +13,7 @@ public class LocalDataStoreApplication implements DataStoreApplication {
 
     @Override
     public void add(byte[] message) {
-        // TODO: this could be bad if postgres succeeds and kafka fails. we need to think about this at some point.
         dataStore.add(message);
-        logStream.send(message);
+        logStream.notifyOfNewEntries();
     }
 }

--- a/app/src/main/java/uk/gov/store/LogStream.java
+++ b/app/src/main/java/uk/gov/store/LogStream.java
@@ -1,29 +1,106 @@
 package uk.gov.store;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 public class LogStream {
+    public static final String HIGH_WATER_MARK_TABLE = "streamed_entries";
+    private final String entryTable;
     private final Producer<String, byte[]> producer;
     public static final String TOPIC_NAME = "register";
+    private final Connection conn;
 
-    public LogStream(String bootstrapServers) {
+    public LogStream(String pgConnectionString, String storeName, String kafkaBootstrapServers) {
         this.producer = new KafkaProducer<>(ImmutableMap.of(
-                "bootstrap.servers", bootstrapServers,
+                "bootstrap.servers", kafkaBootstrapServers,
                 "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
                 "value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer"
         ));
+
+        this.entryTable = storeName + "_STORE";
+
+        try {
+            conn = DriverManager.getConnection(pgConnectionString);
+
+            try (Statement statement = conn.createStatement()) {
+                statement.execute("CREATE TABLE IF NOT EXISTS " + HIGH_WATER_MARK_TABLE + " (ID INTEGER PRIMARY KEY, TIME TIMESTAMP)");
+            }
+        } catch (SQLException e) {
+            throw Throwables.propagate(e);
+        }
     }
 
-    public void send(byte[] message) {
-        producer.send(new ProducerRecord<>(TOPIC_NAME, "primaryKey", message));
+    public void notifyOfNewEntries() {
+        sendNewEntriesToKafka();
+    }
+
+    public void send(int serial, byte[] message) {
+        producer.send(new ProducerRecord<>(TOPIC_NAME, String.valueOf(serial), message));
     }
 
     public void close() throws IOException {
         producer.close();
+    }
+
+    private void sendNewEntriesToKafka() {
+        try {
+            int oldHighWaterMark = getPreviousHighWaterMark();
+
+            sendEntriesToKafkaSince(oldHighWaterMark);
+        } catch (SQLException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private void sendEntriesToKafkaSince(int oldHighWaterMark) throws SQLException {
+        int newHighWaterMark = oldHighWaterMark;
+
+        // send all entries since old high water mark
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT ID,ENTRY FROM " + entryTable + " WHERE ID > ? ORDER BY ID")) {
+            stmt.setInt(1, oldHighWaterMark);
+            try (ResultSet resultSet = stmt.executeQuery()) {
+                while (resultSet.next()) {
+                    send(resultSet.getInt("id"), resultSet.getBytes("entry"));
+                    newHighWaterMark = Math.max(newHighWaterMark, resultSet.getInt("id"));
+                }
+            }
+        }
+
+        // if we actually sent anything new, we need to record that we did
+        if (oldHighWaterMark != newHighWaterMark) {
+            // update high water mark so we don't send these entries again
+            // if this fails, we may send the same entry twice, but that's okay
+            // because it's identified by serial number so the consumer can deduplicate
+            try (PreparedStatement stmt = conn.prepareStatement("INSERT INTO " + HIGH_WATER_MARK_TABLE + " VALUES(?,now())")) {
+                stmt.setInt(1, newHighWaterMark);
+                stmt.execute();
+            }
+        }
+    }
+
+    private int getPreviousHighWaterMark() throws SQLException {
+        int highWaterMark;
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT ID FROM " + HIGH_WATER_MARK_TABLE + " ORDER BY ID DESC LIMIT 1")) {
+            try (ResultSet resultSet = stmt.executeQuery()) {
+                if (resultSet.next()) {
+                    highWaterMark = resultSet.getInt("ID");
+                } else {
+                    // we've never sent anything
+                    highWaterMark = -1;
+                }
+            }
+        }
+        return highWaterMark;
     }
 }

--- a/app/src/main/java/uk/gov/store/LogStream.java
+++ b/app/src/main/java/uk/gov/store/LogStream.java
@@ -1,7 +1,6 @@
 package uk.gov.store;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -16,14 +15,10 @@ public class LogStream {
     private final HighWaterMarkDAO highWaterMarkDAO;
     private final EntriesQueryDAO entriesQueryDAO;
 
-    public LogStream(String kafkaBootstrapServers, HighWaterMarkDAO highWaterMarkDAO, EntriesQueryDAO entriesQueryDAO) {
+    public LogStream(HighWaterMarkDAO highWaterMarkDAO, EntriesQueryDAO entriesQueryDAO, KafkaProducer<String, byte[]> kafkaProducer) {
         this.highWaterMarkDAO = highWaterMarkDAO;
         this.entriesQueryDAO = entriesQueryDAO;
-        this.producer = new KafkaProducer<>(ImmutableMap.of(
-                "bootstrap.servers", kafkaBootstrapServers,
-                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
-                "value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer"
-        ));
+        this.producer = kafkaProducer;
 
         highWaterMarkDAO.ensureTableExists();
     }

--- a/app/src/main/java/uk/gov/store/LogStream.java
+++ b/app/src/main/java/uk/gov/store/LogStream.java
@@ -7,55 +7,44 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
+import java.util.Iterator;
 
 public class LogStream {
-    public static final String HIGH_WATER_MARK_TABLE = "streamed_entries";
-    private final String entryTable;
     private final Producer<String, byte[]> producer;
     public static final String TOPIC_NAME = "register";
-    private final Connection conn;
+    private final HighWaterMarkDAO highWaterMarkDAO;
+    private final EntriesQueryDAO entriesQueryDAO;
 
-    public LogStream(String pgConnectionString, String storeName, String kafkaBootstrapServers) {
+    public LogStream(String kafkaBootstrapServers, HighWaterMarkDAO highWaterMarkDAO, EntriesQueryDAO entriesQueryDAO) {
+        this.highWaterMarkDAO = highWaterMarkDAO;
+        this.entriesQueryDAO = entriesQueryDAO;
         this.producer = new KafkaProducer<>(ImmutableMap.of(
                 "bootstrap.servers", kafkaBootstrapServers,
                 "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
                 "value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer"
         ));
 
-        this.entryTable = storeName + "_STORE";
-
-        try {
-            conn = DriverManager.getConnection(pgConnectionString);
-
-            try (Statement statement = conn.createStatement()) {
-                statement.execute("CREATE TABLE IF NOT EXISTS " + HIGH_WATER_MARK_TABLE + " (ID INTEGER PRIMARY KEY, TIME TIMESTAMP)");
-            }
-        } catch (SQLException e) {
-            throw Throwables.propagate(e);
-        }
+        highWaterMarkDAO.ensureTableExists();
     }
 
     public void notifyOfNewEntries() {
         sendNewEntriesToKafka();
     }
 
-    public void send(int serial, byte[] message) {
-        producer.send(new ProducerRecord<>(TOPIC_NAME, String.valueOf(serial), message));
+    private void send(IndexedEntry entry) {
+        producer.send(new ProducerRecord<>(TOPIC_NAME, String.valueOf(entry.getSerial()), entry.getEntry()));
     }
 
     public void close() throws IOException {
         producer.close();
+        entriesQueryDAO.close();
+        highWaterMarkDAO.close();
     }
 
     private void sendNewEntriesToKafka() {
         try {
-            int oldHighWaterMark = getPreviousHighWaterMark();
+            int oldHighWaterMark = highWaterMarkDAO.getCurrentHighWaterMark();
 
             sendEntriesToKafkaSince(oldHighWaterMark);
         } catch (SQLException e) {
@@ -67,14 +56,11 @@ public class LogStream {
         int newHighWaterMark = oldHighWaterMark;
 
         // send all entries since old high water mark
-        try (PreparedStatement stmt = conn.prepareStatement("SELECT ID,ENTRY FROM " + entryTable + " WHERE ID > ? ORDER BY ID")) {
-            stmt.setInt(1, oldHighWaterMark);
-            try (ResultSet resultSet = stmt.executeQuery()) {
-                while (resultSet.next()) {
-                    send(resultSet.getInt("id"), resultSet.getBytes("entry"));
-                    newHighWaterMark = Math.max(newHighWaterMark, resultSet.getInt("id"));
-                }
-            }
+        Iterator<IndexedEntry> entries = entriesQueryDAO.getEntriesSince(oldHighWaterMark);
+        while (entries.hasNext()) {
+            IndexedEntry entry = entries.next();
+            send(entry);
+            newHighWaterMark = Math.max(newHighWaterMark, entry.getSerial());
         }
 
         // if we actually sent anything new, we need to record that we did
@@ -82,25 +68,7 @@ public class LogStream {
             // update high water mark so we don't send these entries again
             // if this fails, we may send the same entry twice, but that's okay
             // because it's identified by serial number so the consumer can deduplicate
-            try (PreparedStatement stmt = conn.prepareStatement("INSERT INTO " + HIGH_WATER_MARK_TABLE + " VALUES(?,now())")) {
-                stmt.setInt(1, newHighWaterMark);
-                stmt.execute();
-            }
+            highWaterMarkDAO.updateHighWaterMark(newHighWaterMark);
         }
-    }
-
-    private int getPreviousHighWaterMark() throws SQLException {
-        int highWaterMark;
-        try (PreparedStatement stmt = conn.prepareStatement("SELECT ID FROM " + HIGH_WATER_MARK_TABLE + " ORDER BY ID DESC LIMIT 1")) {
-            try (ResultSet resultSet = stmt.executeQuery()) {
-                if (resultSet.next()) {
-                    highWaterMark = resultSet.getInt("ID");
-                } else {
-                    // we've never sent anything
-                    highWaterMark = -1;
-                }
-            }
-        }
-        return highWaterMark;
     }
 }

--- a/app/src/main/java/uk/gov/store/PostgresDataStore.java
+++ b/app/src/main/java/uk/gov/store/PostgresDataStore.java
@@ -7,9 +7,9 @@ public class PostgresDataStore implements DataStore {
     private final Connection connection;
     private final String table;
 
-    public PostgresDataStore(String connectionString, String storeName) {
+    public PostgresDataStore(String connectionString) {
         try {
-            table = storeName + "_STORE";
+            table = EntriesQueryDAO.tableName;
             connection = DriverManager.getConnection(connectionString);
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE IF NOT EXISTS " + table + " (ID SERIAL PRIMARY KEY, ENTRY BYTEA)");

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -6,5 +6,4 @@ rabbitmq.queue=localhost-register-queue
 rabbitmq.exchange.routing.key=localhost-register-queue-routing-key
 
 postgres.connection.string=jdbc:postgresql://localhost:5432/mint
-
-store.name=local
+postgres.database=mint

--- a/app/src/test/java/uk/gov/functional/FunctionalTest.java
+++ b/app/src/test/java/uk/gov/functional/FunctionalTest.java
@@ -10,7 +10,6 @@ import uk.gov.Application;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -102,6 +101,7 @@ public class FunctionalTest {
     private void cleanDatabase() throws SQLException {
         try (Statement statement = pgConnection.createStatement()) {
             statement.execute("DROP TABLE IF EXISTS FUNCTIONAL_TESTS_STORE");
+            statement.execute("DROP TABLE IF EXISTS STREAMED_ENTRIES");
         }
     }
 }

--- a/app/src/test/java/uk/gov/functional/FunctionalTest.java
+++ b/app/src/test/java/uk/gov/functional/FunctionalTest.java
@@ -7,6 +7,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.Application;
+import uk.gov.store.EntriesQueryDAO;
+import uk.gov.store.HighWaterMarkDAO;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,7 +81,7 @@ public class FunctionalTest {
 
     private byte[] tableRecord() throws SQLException {
         try (Statement statement = pgConnection.createStatement()) {
-            statement.execute("SELECT ENTRY FROM FUNCTIONAL_TESTS_STORE");
+            statement.execute("SELECT ENTRY FROM " + EntriesQueryDAO.tableName);
             ResultSet resultSet = statement.getResultSet();
             return resultSet.next() ? resultSet.getBytes(1) : null;
         }
@@ -100,8 +102,8 @@ public class FunctionalTest {
 
     private void cleanDatabase() throws SQLException {
         try (Statement statement = pgConnection.createStatement()) {
-            statement.execute("DROP TABLE IF EXISTS FUNCTIONAL_TESTS_STORE");
-            statement.execute("DROP TABLE IF EXISTS STREAMED_ENTRIES");
+            statement.execute("DROP TABLE IF EXISTS " + EntriesQueryDAO.tableName);
+            statement.execute("DROP TABLE IF EXISTS " + HighWaterMarkDAO.tableName);
         }
     }
 }

--- a/app/src/test/java/uk/gov/store/LogStreamTest.java
+++ b/app/src/test/java/uk/gov/store/LogStreamTest.java
@@ -1,0 +1,97 @@
+package uk.gov.store;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogStreamTest {
+    @Mock
+    private HighWaterMarkDAO highWaterMarkDAO;
+    @Mock
+    private EntriesQueryDAO entriesQueryDAO;
+    @Mock
+    private KafkaProducer<String, byte[]> kafkaProducer;
+
+    @Test
+    public void shouldSendNoEntriesWhenNothingToUpdate() throws Exception {
+        LogStream logStream = new LogStream(highWaterMarkDAO, entriesQueryDAO, kafkaProducer);
+
+        when(highWaterMarkDAO.getCurrentHighWaterMark()).thenReturn(0);
+        whenEntriesAreInDatabase(0, Collections.emptyList());
+
+        logStream.notifyOfNewEntries();
+
+        verifyEntriesAreSent(Collections.emptyList());
+        verifyNoMoreInteractions(kafkaProducer);
+    }
+
+    @Test
+    public void shouldSendOneEntryWhenRequired() throws Exception {
+        LogStream logStream = new LogStream(highWaterMarkDAO, entriesQueryDAO, kafkaProducer);
+
+        ImmutableList<IndexedEntry> entries = ImmutableList.of(entry(1, "entry1"));
+        when(highWaterMarkDAO.getCurrentHighWaterMark()).thenReturn(0);
+        whenEntriesAreInDatabase(0, entries);
+
+        logStream.notifyOfNewEntries();
+
+        verifyEntriesAreSent(entries);
+        verifyNoMoreInteractions(kafkaProducer);
+        verify(highWaterMarkDAO).updateHighWaterMark(1);
+    }
+
+    @Test
+    public void shouldSendMultipleEntriesWhenNotified() throws Exception {
+        LogStream logStream = new LogStream(highWaterMarkDAO, entriesQueryDAO, kafkaProducer);
+
+        ImmutableList<IndexedEntry> entries = ImmutableList.of(entry(1, "entry1"), entry(2, "entry2"));
+        when(highWaterMarkDAO.getCurrentHighWaterMark()).thenReturn(0);
+        whenEntriesAreInDatabase(0, entries);
+
+        logStream.notifyOfNewEntries();
+
+        verifyEntriesAreSent(entries);
+        verifyNoMoreInteractions(kafkaProducer);
+        verify(highWaterMarkDAO).updateHighWaterMark(2);
+    }
+
+    private IndexedEntry entry(int serial, String entry1) {
+        return new IndexedEntry(serial, entry1.getBytes());
+    }
+
+    private OngoingStubbing<Iterator<IndexedEntry>> whenEntriesAreInDatabase(int since, List<IndexedEntry> indexedEntries) {
+        return when(entriesQueryDAO.getEntriesSince(since)).thenReturn(indexedEntries.iterator());
+    }
+
+    private void verifyEntriesAreSent(List<IndexedEntry> entries) {
+        ArgumentCaptor<ProducerRecord> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        verify(kafkaProducer, times(entries.size())).send(captor.capture());
+        List<ProducerRecord> allValues = captor.getAllValues();
+        int index = 0;
+        for (ProducerRecord value : allValues) {
+            IndexedEntry indexedEntry = entries.get(index);
+            assertThat(value.key(), equalTo(String.valueOf(indexedEntry.getSerial())));
+            assertThat(value.topic(), equalTo(LogStream.TOPIC_NAME));
+            assertThat(value.value(), equalTo(indexedEntry.getEntry()));
+            index++;
+        }
+    }
+}

--- a/app/src/test/java/uk/gov/store/PostgresDataStoreTest.java
+++ b/app/src/test/java/uk/gov/store/PostgresDataStoreTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class PostgresDataStoreTest {
 
     private String testPostgresConnectionUri = "jdbc:postgresql://localhost:5432/test_mint";
-    private String tableName = "TEST_STORE";
+    private String tableName = EntriesQueryDAO.tableName;
     private Connection connection;
 
     @Before
@@ -28,7 +28,7 @@ public class PostgresDataStoreTest {
 
     @Test
     public void add_savesTheMessageToTheStoreWithSequenceNumber() throws SQLException {
-        PostgresDataStore postgresDataStore = new PostgresDataStore(testPostgresConnectionUri, "TEST");
+        PostgresDataStore postgresDataStore = new PostgresDataStore(testPostgresConnectionUri);
         assertFalse(records().next());
 
         byte[] message1 = {1, 2, 3};

--- a/app/src/test/resources/test-application.properties
+++ b/app/src/test/resources/test-application.properties
@@ -1,10 +1,9 @@
 kafka.bootstrap.servers=localhost:6001
 
 postgres.connection.string=jdbc:postgresql://localhost:5432/ft_mint
+postgres.database=ft_mint
 
 rabbitmq.connection.string=amqp://127.0.0.1:5672
 rabbitmq.exchange=test-register-exchange
 rabbitmq.queue=test-register-queue
 rabbitmq.exchange.routing.key=test-register-queue-routing-key
-
-store.name=functional_tests

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,6 +1,7 @@
 ext{
 	jOptSimple = 'net.sf.jopt-simple:jopt-simple:4.8'
 	javaslang = 'com.javaslang:javaslang:1.2.2'
+	jdbi = 'org.jdbi:jdbi:2.59'
 	json = [
 		'com.fasterxml.jackson.core:jackson-core:2.5.4',
 		'com.fasterxml.jackson.core:jackson-databind:2.5.4',


### PR DESCRIPTION
As the TODO in LocalDataStoreApplication said, there was a problem where
a write to Postgres could succeed but a write to Kafka could fail.  This
would result in an entry being missed out from the Kafka stream.
Changing the order of these would have the opposite effect -- we could
write entries to the stream which never were written to the database.

This changes the whole LogStream implementation.  Whereas before
LocalDataStoreApplication would write a message to PostgresDataStore and
LogStream, now it writes to PostgresDataStore and notifies LogStream
that there are new entries available.

LogStream then queries the database to find which new entries exist,
send all new entries, and record that they were sent, in a high water
mark table (called `streamed_entries`).  The table serves as a log of
which messages were sent at which time.

There are still failure modes where a message can be sent to kafka and
then an exception causes the new high water mark not to be recorded in
the streamed_entries table.  To deal with this, we now use the entry's
serial number as the Kafka primary key (which is _not_ the register
primary key), and allow the consumer to deduplicate multiple messages
with the same primary key.  (We can also get Kafka to forget about old
messages with the same primary key, which is a safe operation since such
messages are guaranteed to be byte-for-byte identical).

As a side-effect, this makes the entry serial number visible to
consumers, which may become useful for constructing permalink URLs in
future.
