### PR TITLE
allow user to specify relative path to bulk loader

### DIFF
--- a/loader/build.gradle
+++ b/loader/build.gradle
@@ -27,9 +27,9 @@ jar {
     }
 }
 
-task bulkLoad(type: JavaExec)  {
+task bulkLoad(type: JavaExec) {
     def properties = project.getProperties()
-    def datafile = properties.get("datafile")
+    def datafile = properties.get("datafile") == null ? null : new File((String) properties.get("datafile")).absolutePath
     def mintUrl = properties.get("mintUrl")
     def type = properties.get("type") == null ? "jsonl" : properties.get("type")
 


### PR DESCRIPTION
I was having issues where running `gradle bulkLoad` from the project
root would give errors that the loader couldn't find the file I was
specifying.  I'd get a FileNotFoundException saying that
/path/to/mint/loader/../country.register/data/Country/countries.tsv was
not a file or directory.  However I wasn't running gradle from
/path/to/mint/loader, I was running it from /path/to/mint, and relative
to that directory, my relative path was valid.

To ensure the relative path is treated correctly, this commit ensures
that the path is resolved by gradle (which knows where the user is
running the directory from) rather than by the loader.jar (which gets
run from the mint/loader directory regardless of where the user
originally ran gradle from).
