### PR TITLE
deploy mint against RDS instead of docker postgres

### DIFF
--- a/app/deploy/scripts/start-service.sh
+++ b/app/deploy/scripts/start-service.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+aws s3 cp s3://preview.config/mint/mint.properties /srv/mint --region eu-west-1
 docker run -d --name=mintApp -p 4567:4567 \
     --volume /srv/mint:/srv/mint \
-    --link etc_postgres_1:postgres \
     --link etc_kafka_1:kafka \
-    jstepien/openjdk8 java -jar /srv/mint/mint.jar
+    jstepien/openjdk8 java -jar /srv/mint/mint.jar config.file=/srv/mint/mint.properties


### PR DESCRIPTION
In order to talk to RDS, we need to have configuration for where to find
the RDS endpoint and what username and password to use.  This commit
achieves this according to the strategy suggested on the [amazon security blog](http://blogs.aws.amazon.com/security/post/Tx610S2MLVZWEA/Using-IAM-roles-to-distribute-non-AWS-credentials-to-your-EC2-instances),
where you store your configuration file in S3 and use IAM
Roles for EC2 instances to control access to the S3 bucket.

**ATTENTION:** this PR needs to be synchronized with a change to the deployment repository to update the create-env.sh script to allow access to security groups appropriately.
