### PR TITLE
stop scripts should always return exit code 0. it is specially requir…

### DIFF
--- a/app/deploy/scripts/stop-service.sh
+++ b/app/deploy/scripts/stop-service.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -x
 docker stop mintApp
 docker rm mintApp
+exit 0
+


### PR DESCRIPTION
stop scripts should always return exit code 0. it is specially required when you deploy first time on an instance where no docker process is running. assuming that the docker container will always be removed if exists.
