### PR TITLE
Allow different instances to have different configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ deploy:
   region: eu-west-1
   skip_cleanup: true
   on: &2
-    branch: master
+    branch: custom-config
     condition: $DEPLOY=true
 - provider: codedeploy
   access_key_id: AKIAI5JSOOUBYFGE7NEA

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ deploy:
   region: eu-west-1
   skip_cleanup: true
   on: &2
-    branch: custom-config
+    branch: master
     condition: $DEPLOY=true
 - provider: codedeploy
   access_key_id: AKIAI5JSOOUBYFGE7NEA

--- a/app/deploy/scripts/start-service.sh
+++ b/app/deploy/scripts/start-service.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-aws s3 cp s3://preview.config/mint/mint.properties /srv/mint --region eu-west-1
+INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
+export AWS_DEFAULT_REGION=eu-west-1
+REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Name --query 'Tags[0].Value' --output text)
+
+aws s3 cp s3://preview.config/${REGISTER_NAME}/mint/mint.properties /srv/mint --region eu-west-1
 docker run -d --name=mintApp -p 4567:4567 \
     --volume /srv/mint:/srv/mint \
     --link etc_kafka_1:kafka \


### PR DESCRIPTION
When deploying, pull configuration from a different location depending on register name, so that different registers can use different database configuration.
