### PR TITLE
Using character encoding constant instead of specifying raw string

### DIFF
--- a/app/src/main/java/uk/gov/mint/Digest.java
+++ b/app/src/main/java/uk/gov/mint/Digest.java
@@ -2,16 +2,17 @@ package uk.gov.mint;
 
 import org.apache.commons.codec.binary.Hex;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 //TODO: Copied from alpha register to generate hash, We need to figure out what hashing technique is required
 class Digest {
     public static String shasum(String raw) {
         try {
-            String head = "blob " + raw.getBytes("UTF-8").length + "\0";
+            String head = "blob " + raw.getBytes(StandardCharsets.UTF_8).length + "\0";
 
             MessageDigest md = MessageDigest.getInstance("SHA-1");
-            md.update((head + raw).getBytes("UTF-8"));
+            md.update((head + raw).getBytes(StandardCharsets.UTF_8));
             return new String(Hex.encodeHex(md.digest()));
 
         } catch (Exception e) {

--- a/app/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/app/src/main/java/uk/gov/mint/LoadHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import uk.gov.store.EntriesUpdateDAO;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,7 +28,7 @@ public class LoadHandler {
         final List<byte[]> entriesAsBytes = Arrays.stream(entries)
                 .map(e -> {
                     try {
-                        final JsonNode jsonNode = canonicalJsonMapper.readFromBytes(e.getBytes("UTF-8"));
+                        final JsonNode jsonNode = canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8));
                         return canonicalJsonMapper.writeToBytes(hashedEntry(jsonNode));
                     } catch (Exception e1) {
                         throw new RuntimeException("Error parsing json entry: " + e, e1);

--- a/app/src/test/java/uk/gov/mint/LoadHandlerTest.java
+++ b/app/src/test/java/uk/gov/mint/LoadHandlerTest.java
@@ -10,6 +10,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.store.EntriesUpdateDAO;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -51,7 +52,7 @@ public class LoadHandlerTest {
 
     private byte[] canonicalise(String nonCanonical) throws IOException {
         CanonicalJsonMapper canonicalJsonMapper = new CanonicalJsonMapper();
-        final JsonNode jsonNode = canonicalJsonMapper.readFromBytes(nonCanonical.getBytes("UTF-8"));
+        final JsonNode jsonNode = canonicalJsonMapper.readFromBytes(nonCanonical.getBytes(StandardCharsets.UTF_8));
         return canonicalJsonMapper.writeToBytes(jsonNode);
     }
 }


### PR DESCRIPTION
Using character encoding constant instead of specifying raw string
