### PR TITLE
All database queries must be written in lowercase characters

### DIFF
--- a/app/src/main/java/uk/gov/store/EntriesUpdateDAO.java
+++ b/app/src/main/java/uk/gov/store/EntriesUpdateDAO.java
@@ -10,10 +10,10 @@ import java.util.List;
 public interface EntriesUpdateDAO {
     String tableName = "entries";
 
-    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + tableName + " (ID SERIAL PRIMARY KEY, ENTRY BYTEA)")
+    @SqlUpdate("create table if not exists " + tableName + " (id serial primary key, entry bytea)")
     void ensureTableExists();
 
-    @SqlBatch("INSERT INTO " + tableName + "(ENTRY) values(:messages)")
+    @SqlBatch("insert into " + tableName + " (entry) values(:messages)")
     @BatchChunkSize(1000)
     void add(@Bind("messages") List<byte[]> messages);
 }


### PR DESCRIPTION
All queries must be written in lowercase characters to remove any confusion and probable bug.

 Postgres entities are created as all lowercase characters. we faced a problem in indexer app in which where clause was specifying an index name in uppercase and the condition was never met (https://github.com/openregister/indexer/pull/23).
