### PR TITLE
bump dropwizard to 0.9.1

### DIFF
--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
 
-    dropwizard_version = '0.8.2'
+    dropwizard_version = '0.9.1'
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",


### PR DESCRIPTION
There's a [migration guide](https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-0.8.x-to-0.9.x) though it seems that we're not using
anything that needs migrating.
