### PR TITLE
Using register name from configuration only

### DIFF
--- a/app/src/main/java/uk/gov/MintApplication.java
+++ b/app/src/main/java/uk/gov/MintApplication.java
@@ -53,10 +53,10 @@ public class MintApplication extends Application<MintConfiguration> {
 
         EntryValidator entryValidator = new EntryValidator(registersConfiguration, fieldsConfiguration);
 
-        LoadHandler loadHandler = new LoadHandler(jdbi.onDemand(EntriesUpdateDAO.class), entryValidator);
+        LoadHandler loadHandler = new LoadHandler(configuration.getRegister(), jdbi.onDemand(EntriesUpdateDAO.class), entryValidator);
 
         JerseyEnvironment jersey = environment.jersey();
-        jersey.register(new MintService(configuration.getRegister(), loadHandler));
+        jersey.register(new MintService(loadHandler));
     }
 }
 

--- a/app/src/main/java/uk/gov/MintConfiguration.java
+++ b/app/src/main/java/uk/gov/MintConfiguration.java
@@ -16,6 +16,7 @@ public class MintConfiguration extends Configuration {
 
     @SuppressWarnings("unused")
     @Valid
+    @NotNull
     @JsonProperty
     private String register;
 

--- a/app/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/app/src/main/java/uk/gov/mint/LoadHandler.java
@@ -13,26 +13,28 @@ import java.util.stream.Collectors;
 
 public class LoadHandler {
     private final CanonicalJsonMapper canonicalJsonMapper;
+    private final String register;
     private final EntriesUpdateDAO entriesUpdateDAO;
     private final EntryValidator entryValidator;
 
-    public LoadHandler(EntriesUpdateDAO entriesUpdateDAO, EntryValidator entryValidator) {
+    public LoadHandler(String register, EntriesUpdateDAO entriesUpdateDAO, EntryValidator entryValidator) {
+        this.register = register;
         this.entriesUpdateDAO = entriesUpdateDAO;
         this.entryValidator = entryValidator;
         this.canonicalJsonMapper = new CanonicalJsonMapper();
         entriesUpdateDAO.ensureTableExists();
     }
 
-    public void handle(String registerName, String payload) {
-        processEntries(registerName, payload.split("\n"));
+    public void handle(String payload) {
+        processEntries(payload.split("\n"));
     }
 
-    private void processEntries(String registerName, String[] entries) {
+    private void processEntries(String[] entries) {
         final List<byte[]> entriesAsBytes = Arrays.stream(entries)
                 .map(e -> {
                     try {
                         final JsonNode jsonNode = canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8));
-                        entryValidator.validateEntry(registerName, jsonNode);
+                        entryValidator.validateEntry(register, jsonNode);
                         return canonicalJsonMapper.writeToBytes(hashedEntry(jsonNode));
                     } catch (Exception ex) {
                         throw Throwables.propagate(ex);

--- a/app/src/main/java/uk/gov/mint/MintService.java
+++ b/app/src/main/java/uk/gov/mint/MintService.java
@@ -1,7 +1,5 @@
 package uk.gov.mint;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -10,11 +8,9 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 public class MintService {
-    private final String register;
     private final LoadHandler loadHandler;
 
-    public MintService(String register, LoadHandler loadHandler) {
-        this.register = register;
+    public MintService(LoadHandler loadHandler) {
         this.loadHandler = loadHandler;
     }
 
@@ -25,20 +21,12 @@ public class MintService {
     @Path("/load")
     public Response load(String payload) {
         try {
-            loadHandler.handle(extractRegisterNameFromRequest(), payload);
+            loadHandler.handle(payload);
             return Response.ok().build();
         } catch (EntryValidationException e) {
             return Response.status(400).entity(e.getMessage() + " Error entry: '" + e.getEntry().toString() + "'").build();
         } catch (Exception e) {
             return Response.serverError().entity(e).build();
         }
-    }
-
-    protected String extractRegisterNameFromRequest() {
-        if(StringUtils.isNotBlank(register)){
-            return register;
-        }
-        String host = httpServletRequest.getHeader("Host");
-        return host.split(":")[0].split("\\.")[0];
     }
 }

--- a/app/src/test/java/uk/gov/mint/LoadHandlerTest.java
+++ b/app/src/test/java/uk/gov/mint/LoadHandlerTest.java
@@ -32,7 +32,7 @@ public class LoadHandlerTest {
 
     @Test
     public void handle_addsTheHashAndThenSavesInTheDatabase() throws Exception {
-        LoadHandler loadHandler = new LoadHandler(entriesUpdateDAO, new EntryValidator(new RegistersConfiguration(Optional.empty()), new FieldsConfiguration(Optional.empty())));
+        LoadHandler loadHandler = new LoadHandler("register", entriesUpdateDAO, new EntryValidator(new RegistersConfiguration(Optional.empty()), new FieldsConfiguration(Optional.empty())));
 
         String payload = "{\"register\":\"value1\"}\n{\"register\":\"value2\"}";
 
@@ -44,7 +44,7 @@ public class LoadHandlerTest {
         final String entry2 = "{\"entry\":{\"register\":\"value2\"},\"hash\":\"" + expectedHash2 + "\"}";
         final byte[] entry2Bytes = canonicalise(entry2);
 
-        loadHandler.handle("register", payload);
+        loadHandler.handle(payload);
 
         verify(entriesUpdateDAO, times(1)).add(entriesCaptor.capture());
         final List<byte[]> payloadArray = entriesCaptor.getValue();

--- a/app/src/test/resources/test-config.yaml
+++ b/app/src/test/resources/test-config.yaml
@@ -10,3 +10,5 @@ server:
   applicationConnectors:
   - type: http
     port: 4568
+
+register: register


### PR DESCRIPTION
PR https://github.com/openregister/mint/pull/38 introduced a property 'register' in configuration to configure the register name, but it was not a mandatory property.

We have updated all registers configurations on s3 to make configuration property mandatory which allowed us to remove the code to extract register name from host.
