### PR TITLE
support basic auth

### DIFF
--- a/app/src/main/java/uk/gov/MintConfiguration.java
+++ b/app/src/main/java/uk/gov/MintConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import uk.gov.mint.auth.MintAuthenticatorFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -13,6 +14,10 @@ public class MintConfiguration extends Configuration {
     @NotNull
     @JsonProperty
     private DataSourceFactory database;
+
+    @Valid
+    @JsonProperty
+    private MintAuthenticatorFactory credentials = new MintAuthenticatorFactory();
 
     @SuppressWarnings("unused")
     @Valid
@@ -26,5 +31,9 @@ public class MintConfiguration extends Configuration {
 
     public String getRegister() {
         return register;
+    }
+
+    public MintAuthenticatorFactory getAuthenticator() {
+        return credentials;
     }
 }

--- a/app/src/main/java/uk/gov/mint/MintService.java
+++ b/app/src/main/java/uk/gov/mint/MintService.java
@@ -1,5 +1,6 @@
 package uk.gov.mint;
 
+import javax.annotation.security.PermitAll;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -18,6 +19,7 @@ public class MintService {
     HttpServletRequest httpServletRequest;
 
     @POST
+    @PermitAll
     @Path("/load")
     public Response load(String payload) {
         try {

--- a/app/src/main/java/uk/gov/mint/User.java
+++ b/app/src/main/java/uk/gov/mint/User.java
@@ -1,0 +1,8 @@
+package uk.gov.mint;
+
+public class User implements java.security.Principal {
+    @Override
+    public String getName() {
+        return "default user";
+    }
+}

--- a/app/src/main/java/uk/gov/mint/auth/MintAuthenticator.java
+++ b/app/src/main/java/uk/gov/mint/auth/MintAuthenticator.java
@@ -1,0 +1,25 @@
+package uk.gov.mint.auth;
+
+import com.google.common.base.Optional;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.basic.BasicCredentials;
+import uk.gov.mint.User;
+
+public class MintAuthenticator implements Authenticator<BasicCredentials, User> {
+    private final String expectedUsername;
+    private final String expectedPassword;
+
+    public MintAuthenticator(String expectedUsername, String expectedPassword) {
+        this.expectedUsername = expectedUsername;
+        this.expectedPassword = expectedPassword;
+    }
+
+    @Override
+    public Optional<User> authenticate(BasicCredentials credentials) throws AuthenticationException {
+        if (credentials.getUsername().equals(expectedUsername) && credentials.getPassword().equals(expectedPassword)) {
+            return Optional.of(new User());
+        }
+        return Optional.absent();
+    }
+}

--- a/app/src/main/java/uk/gov/mint/auth/MintAuthenticatorFactory.java
+++ b/app/src/main/java/uk/gov/mint/auth/MintAuthenticatorFactory.java
@@ -1,0 +1,23 @@
+package uk.gov.mint.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+public class MintAuthenticatorFactory {
+    @Valid
+    @JsonProperty
+    private String user;
+
+    @Valid
+    @JsonProperty
+    private String password;
+
+    public Optional<MintAuthenticator> build() {
+        if (user != null && password != null) {
+            return Optional.of(new MintAuthenticator(user, password));
+        }
+        return Optional.empty();
+    }
+}

--- a/app/src/test/resources/test-config.yaml
+++ b/app/src/test/resources/test-config.yaml
@@ -12,3 +12,7 @@ server:
     port: 4568
 
 register: register
+
+credentials:
+  user: foo
+  password: bar

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -4,6 +4,7 @@ ext {
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",
+            "io.dropwizard:dropwizard-auth:${dropwizard_version}",
             "io.dropwizard:dropwizard-configuration:${dropwizard_version}",
             "io.dropwizard:dropwizard-jdbi:${dropwizard_version}",
             "io.dropwizard:dropwizard-logging:${dropwizard_version}"


### PR DESCRIPTION
This adds (optional) basic auth support to the mint.  You add
configuration such as:

```
credentials:
    user: foo
    password: bar
```

As it is basic auth, the password is stored in plain text.  This is
clearly not a long-term solution for authenticating the API.
