### PR TITLE
Running mint app with external registers and fields configuration

### DIFF
--- a/app/deploy/scripts/start-service.sh
+++ b/app/deploy/scripts/start-service.sh
@@ -8,6 +8,10 @@ ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=
 CONFIG_BUCKET=openregister.${ENV}.config
 
 aws s3 cp s3://${CONFIG_BUCKET}/${REGISTER_NAME}/mint/mint-config.yaml /srv/mint --region eu-west-1
+
+aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/mint --region eu-west-1
+aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/mint --region eu-west-1
+
 docker run -d --name=mintApp -p 4567:4567 \
     --volume /srv/mint:/srv/mint \
-    jstepien/openjdk8 java -Dfile.encoding=UTF-8 -jar /srv/mint/mint.jar server /srv/mint/mint-config.yaml
+    jstepien/openjdk8 java -Dfile.encoding=UTF-8 -DregistersYaml=/srv/mint/registers.yaml -DfieldsYaml=/srv/mint/fields.yaml -jar /srv/mint/mint.jar server /srv/mint/mint-config.yaml


### PR DESCRIPTION
registers.yaml and fields.yaml files are loaded on S3 buckets. 

before starting the application both registers and fields configuration files are fetched from s3 and their path is passed as system property to java process.
