### PR TITLE
Better error message when input is not valid jsonl

### DIFF
--- a/app/src/main/java/uk/gov/MintApplication.java
+++ b/app/src/main/java/uk/gov/MintApplication.java
@@ -11,10 +11,7 @@ import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.skife.jdbi.v2.DBI;
-import uk.gov.mint.EntryValidator;
-import uk.gov.mint.LoadHandler;
-import uk.gov.mint.MintService;
-import uk.gov.mint.User;
+import uk.gov.mint.*;
 import uk.gov.register.FieldsConfiguration;
 import uk.gov.register.RegistersConfiguration;
 import uk.gov.store.EntriesUpdateDAO;
@@ -58,6 +55,10 @@ public class MintApplication extends Application<MintConfiguration> {
 
         JerseyEnvironment jersey = environment.jersey();
         jersey.register(new MintService(loadHandler));
+
+        jersey.register(EntryValidationExceptionMapper.class);
+        jersey.register(JsonParseExceptionMapper.class);
+        jersey.register(ThrowableExceptionMapper.class);
 
         configuration.getAuthenticator().build()
                 .ifPresent(authenticator ->

--- a/app/src/main/java/uk/gov/mint/EntryValidationExceptionMapper.java
+++ b/app/src/main/java/uk/gov/mint/EntryValidationExceptionMapper.java
@@ -1,0 +1,12 @@
+package uk.gov.mint;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class EntryValidationExceptionMapper implements ExceptionMapper<EntryValidationException> {
+
+    @Override
+    public Response toResponse(EntryValidationException exception) {
+        return Response.status(400).entity(exception.getMessage() + " Error entry: '" + exception.getEntry().toString() + "'").build();
+    }
+}

--- a/app/src/main/java/uk/gov/mint/ExceptionUtils.java
+++ b/app/src/main/java/uk/gov/mint/ExceptionUtils.java
@@ -1,0 +1,13 @@
+package uk.gov.mint;
+
+class ExceptionUtils {
+    @SuppressWarnings("unchecked")
+    private static <T extends Exception> void throwAsUnchecked(Throwable exception) throws T {
+        throw (T) exception;
+    }
+
+    public static <M, T extends Exception> M rethrow(T ex) {
+        throwAsUnchecked(ex);
+        return null;
+    }
+}

--- a/app/src/main/java/uk/gov/mint/JsonParseExceptionMapper.java
+++ b/app/src/main/java/uk/gov/mint/JsonParseExceptionMapper.java
@@ -1,0 +1,13 @@
+package uk.gov.mint;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
+    @Override
+    public Response toResponse(JsonParseException exception) {
+        return Response.status(400).entity("Error parsing json input: "  + exception.getMessage()).build();
+    }
+}

--- a/app/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/app/src/main/java/uk/gov/mint/LoadHandler.java
@@ -38,6 +38,8 @@ public class LoadHandler {
 //                        entryValidator.validateEntry(register, jsonNode);
                         return canonicalJsonMapper.writeToBytes(hashedEntry(jsonNode));
                     } catch (Exception ex) {
+                        //Rethrowing this error using ExceptionUtils because I want to return
+                        //the JsonParseException to the caller of processEntries method. This will be then handled by JsonParseExceptionMapper.
                         return ExceptionUtils.rethrow(ex);
                     }
                 })

--- a/app/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/app/src/main/java/uk/gov/mint/LoadHandler.java
@@ -3,7 +3,6 @@ package uk.gov.mint;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Throwables;
 import uk.gov.store.EntriesUpdateDAO;
 
 import java.nio.charset.StandardCharsets;
@@ -39,7 +38,7 @@ public class LoadHandler {
 //                        entryValidator.validateEntry(register, jsonNode);
                         return canonicalJsonMapper.writeToBytes(hashedEntry(jsonNode));
                     } catch (Exception ex) {
-                        throw Throwables.propagate(ex);
+                        return ExceptionUtils.rethrow(ex);
                     }
                 })
                 .collect(Collectors.toList());
@@ -54,4 +53,3 @@ public class LoadHandler {
     }
 
 }
-

--- a/app/src/main/java/uk/gov/mint/MintService.java
+++ b/app/src/main/java/uk/gov/mint/MintService.java
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 
 @Path("/")
 public class MintService {
@@ -21,14 +20,7 @@ public class MintService {
     @POST
     @PermitAll
     @Path("/load")
-    public Response load(String payload) {
-        try {
-            loadHandler.handle(payload);
-            return Response.ok().build();
-        } catch (EntryValidationException e) {
-            return Response.status(400).entity(e.getMessage() + " Error entry: '" + e.getEntry().toString() + "'").build();
-        } catch (Exception e) {
-            return Response.serverError().entity(e).build();
-        }
+    public void load(String payload) {
+        loadHandler.handle(payload);
     }
 }

--- a/app/src/main/java/uk/gov/mint/ThrowableExceptionMapper.java
+++ b/app/src/main/java/uk/gov/mint/ThrowableExceptionMapper.java
@@ -1,0 +1,11 @@
+package uk.gov.mint;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ThrowableExceptionMapper implements ExceptionMapper<Throwable> {
+    @Override
+    public Response toResponse(Throwable throwable) {
+        return Response.serverError().entity(throwable.getMessage()).build();
+    }
+}

--- a/app/src/test/java/uk/gov/functional/FunctionalTest.java
+++ b/app/src/test/java/uk/gov/functional/FunctionalTest.java
@@ -73,7 +73,7 @@ public class FunctionalTest {
         Response response = jerseyClient.target("http://localhost:4568/load")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.json(String.join("\n", payload)));
-        if (response.getStatus() != 200) {
+        if (response.getStatus() != 204) {
             throw new RuntimeException("Unexpected result: " + response.readEntity(String.class));
         }
         System.out.println("Loaded " + payload.size() + " entries...");

--- a/app/src/test/java/uk/gov/mint/JsonParseExceptionMapperTest.java
+++ b/app/src/test/java/uk/gov/mint/JsonParseExceptionMapperTest.java
@@ -1,0 +1,21 @@
+package uk.gov.mint;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+
+public class JsonParseExceptionMapperTest {
+    @Test
+    public void toResponse_returns400Response() {
+        JsonParseExceptionMapper jsonParseExceptionMapper = new JsonParseExceptionMapper();
+        Response response = jsonParseExceptionMapper.toResponse(new JsonParseException("some message", null));
+
+        assertThat(response.getStatus(), equalTo(400));
+        assertThat(response.getEntity(), equalTo("Error parsing json input: some message"));
+    }
+}

--- a/app/src/test/java/uk/gov/mint/ThrowableExceptionMapperTest.java
+++ b/app/src/test/java/uk/gov/mint/ThrowableExceptionMapperTest.java
@@ -1,0 +1,20 @@
+package uk.gov.mint;
+
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+
+public class ThrowableExceptionMapperTest {
+    @Test
+    public void toResponse_returns500Response() {
+        ThrowableExceptionMapper throwableExceptionMapper = new ThrowableExceptionMapper();
+        Response response = throwableExceptionMapper.toResponse(new Exception("some message"));
+
+        assertThat(response.getStatus(), equalTo(500));
+        assertThat(response.getEntity(), equalTo("some message"));
+    }
+}


### PR DESCRIPTION
The app throws an error when the input entry is not a valid jsonl. The error response was 500 status and the error message was `{"code":500,"message":"HTTP 500 Internal Server Error"}`. It shouldn't be 500 response because the error was because of wrong input entry and also the error message was not very helpful.

Now we are returning much better error with 400 error response.
