### PR TITLE
Unit test JsonParseException

### DIFF
--- a/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/src/main/java/uk/gov/mint/LoadHandler.java
@@ -38,8 +38,6 @@ public class LoadHandler {
 //                        entryValidator.validateEntry(register, jsonNode);
                         return canonicalJsonMapper.writeToBytes(hashedEntry(jsonNode));
                     } catch (Exception ex) {
-                        //Rethrowing this error using ExceptionUtils because I want to return
-                        //the JsonParseException to the caller of processEntries method. This will be then handled by JsonParseExceptionMapper.
                         return ExceptionUtils.rethrow(ex);
                     }
                 })


### PR DESCRIPTION
Written unit test to confirm that JsonParseException is thrown from LoadHandler if input is not valid jsonl. This was required to remove comment which was earlier conveying the message of using ExceptionUtils.
