### PR TITLE
Use guava directly, avoid jersey's repackaged guava

### DIFF
--- a/src/main/java/uk/gov/mint/EntryValidator.java
+++ b/src/main/java/uk/gov/mint/EntryValidator.java
@@ -2,7 +2,7 @@ package uk.gov.mint;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterators;
-import jersey.repackaged.com.google.common.collect.Sets;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.register.*;
 import uk.gov.register.datatype.Datatype;


### PR DESCRIPTION
We shouldn't use jersey's repackaged guava, we should use the one we
pull in directly.

Presumably Jersey repackages guava so that it can have a different
version than whatever one we pull in.
