### PR TITLE
Resolved bug: integer data type regex validation was incorrect

### DIFF
--- a/src/main/java/uk/gov/register/datatype/IntegerDatatype.java
+++ b/src/main/java/uk/gov/register/datatype/IntegerDatatype.java
@@ -11,7 +11,7 @@ public class IntegerDatatype implements Datatype {
 
     @Override
     public boolean isValid(JsonNode value) {
-        return value.isTextual() && value.textValue().matches("^[-]?\\d+$");
+        return value.isTextual() && value.textValue().matches("^-?[1-9][0-9]*|0$");
     }
 
     public String getName() {

--- a/src/test/java/uk/gov/register/datatype/IntegerDatatypeTest.java
+++ b/src/test/java/uk/gov/register/datatype/IntegerDatatypeTest.java
@@ -13,11 +13,17 @@ public class IntegerDatatypeTest {
     @Test
     public void isValid_true_whenValueIsAnIntegerValue() {
         assertTrue(integerDatatype.isValid(TextNode.valueOf("5")));
+        assertTrue(integerDatatype.isValid(TextNode.valueOf("0")));
+        assertTrue(integerDatatype.isValid(TextNode.valueOf("1500")));
+        assertTrue(integerDatatype.isValid(TextNode.valueOf("-1500")));
     }
 
     @Test
     public void isValid_false_whenValueIsNotAnIntegerValue() {
         assertFalse(integerDatatype.isValid(TextNode.valueOf("5a")));
+        assertFalse(integerDatatype.isValid(TextNode.valueOf("-0")));
+        assertFalse(integerDatatype.isValid(TextNode.valueOf("007")));
+        assertFalse(integerDatatype.isValid(TextNode.valueOf("-007")));
     }
 
     @Test


### PR DESCRIPTION
Earlier the regex was allowing `-0` and `007` kind of pattern to pass the validation. Changed the regex so that only integer values are allowed.
