### PR TITLE
ensure we close the request object even in error conditions

### DIFF
--- a/src/main/java/uk/gov/mint/CTHandler.java
+++ b/src/main/java/uk/gov/mint/CTHandler.java
@@ -34,10 +34,13 @@ public class CTHandler implements Loader {
         entries.forEach(singleEntry -> {
             Response response = wt.request()
                     .post(Entity.entity(singleEntry, MediaType.APPLICATION_JSON), Response.class);
-            if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                throw new CTException(response.getStatus(), response.readEntity(String.class));
+            try {
+                if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+                    throw new CTException(response.getStatus(), response.readEntity(String.class));
+                }
+            } finally {
+                response.close();
             }
-            response.close();
         });
     }
 }


### PR DESCRIPTION
previously, if we threw an exception we wouldn't have closed the
request.

I'd rather have used try-with-resources but Request doesn't implement
AutoCloseable so that won't work :(
