### PR TITLE
integer and url validations passes if the field contains "" string.

### DIFF
--- a/src/main/java/uk/gov/register/datatype/IntegerDatatype.java
+++ b/src/main/java/uk/gov/register/datatype/IntegerDatatype.java
@@ -11,7 +11,7 @@ public class IntegerDatatype implements Datatype {
 
     @Override
     public boolean isValid(JsonNode value) {
-        return value.isTextual() && value.textValue().matches("^-?[1-9][0-9]*|0$");
+        return value.isTextual() && value.textValue().matches("^-?[1-9][0-9]*|0|$");
     }
 
     public String getName() {

--- a/src/main/java/uk/gov/register/datatype/UrlDatatype.java
+++ b/src/main/java/uk/gov/register/datatype/UrlDatatype.java
@@ -15,6 +15,11 @@ public class UrlDatatype implements Datatype {
     @Override
     public boolean isValid(JsonNode value) {
         String url = value.textValue();
+
+        if(url.equals("")){
+            return true;
+        }
+
         try {
             new URL(url);
             return true;

--- a/src/test/java/uk/gov/register/datatype/IntegerDatatypeTest.java
+++ b/src/test/java/uk/gov/register/datatype/IntegerDatatypeTest.java
@@ -19,6 +19,11 @@ public class IntegerDatatypeTest {
     }
 
     @Test
+    public void isValid_true_whenValueIsAnEmptyString_becauseAFieldCanHaveOptionalIntegerValue(){
+        assertTrue(integerDatatype.isValid(TextNode.valueOf("")));
+    }
+
+    @Test
     public void isValid_false_whenValueIsNotAnIntegerValue() {
         assertFalse(integerDatatype.isValid(TextNode.valueOf("5a")));
         assertFalse(integerDatatype.isValid(TextNode.valueOf("-0")));

--- a/src/test/java/uk/gov/register/datatype/UrlDatatypeTest.java
+++ b/src/test/java/uk/gov/register/datatype/UrlDatatypeTest.java
@@ -9,13 +9,20 @@ import static org.junit.Assert.assertTrue;
 public class UrlDatatypeTest {
     UrlDatatype urlDatatype = new UrlDatatype("url");
     @Test
-    public void isValid_true_onlyWhenAValidURlStringValue() {
+    public void isValid_true_whenAValidUrlStringValue() {
         assertTrue(urlDatatype.isValid(TextNode.valueOf("http://foo/ff")));
         assertTrue(urlDatatype.isValid(TextNode.valueOf("ftp://foo/ff")));
     }
 
     @Test
+    public void isValid_true_whenValueIsEmptyString_becauseUrlValueCanBeAnOptionalInRegister(){
+        assertTrue(urlDatatype.isValid(TextNode.valueOf("")));
+    }
+
+    @Test
     public void isValid_false_whenStringValueIsNotValidUrl() {
         assertFalse(urlDatatype.isValid(TextNode.valueOf("http//foo/ff")));
+        assertFalse(urlDatatype.isValid(TextNode.valueOf("http;//www.rmplc.co.uk/eduweb/sites/barnwell/index.html")));
     }
+
 }


### PR DESCRIPTION
  We create the input json entry by loader, some of the field values can be optional like 'website'. so validations should allow "" string as valid value of integer and url field values.
  Register should tell that which field must have mandatory value. we don't have mandatory value concept atm.
