### PR TITLE
Checks the String datatype to ensure it's non-blank.

### DIFF
--- a/src/main/java/uk/gov/register/datatype/StringDatatype.java
+++ b/src/main/java/uk/gov/register/datatype/StringDatatype.java
@@ -11,10 +11,13 @@ public class StringDatatype implements Datatype {
 
     @Override
     public boolean isValid(JsonNode value) {
-        return value.isTextual();
+        if (value.isTextual() && (value.textValue() != null && !value.textValue().isEmpty())) {
+            return true;
+        }
+        return false;
     }
 
-    public String getName(){
+    public String getName() {
         return datatypeName;
     }
 }

--- a/src/main/java/uk/gov/register/datatype/StringDatatype.java
+++ b/src/main/java/uk/gov/register/datatype/StringDatatype.java
@@ -1,6 +1,7 @@
 package uk.gov.register.datatype;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
 
 public class StringDatatype implements Datatype {
     private final String datatypeName;
@@ -11,7 +12,7 @@ public class StringDatatype implements Datatype {
 
     @Override
     public boolean isValid(JsonNode value) {
-        if (value.isTextual() && (value.textValue() != null && !value.textValue().isEmpty())) {
+        if (value.isTextual() && StringUtils.isNotBlank(value.textValue())) {
             return true;
         }
         return false;

--- a/src/test/java/uk/gov/mint/EntryValidatorTest.java
+++ b/src/test/java/uk/gov/mint/EntryValidatorTest.java
@@ -108,4 +108,17 @@ public class EntryValidatorTest {
     private JsonNode nodeOf(String jsonString) throws IOException {
         return objectMapper.readValue(jsonString, JsonNode.class);
     }
+
+    @Test
+    public void validateEntry_failsOnEmptyStringField() throws IOException {
+        String jsonString = "{\"register\":\"aregister\",\"fields\":[\"foo\",\"\"]}";
+        JsonNode jsonNode = nodeOf(jsonString);
+        try {
+            entryValidator.validateEntry("register", jsonNode);
+            fail("Must not execute this statement");
+        } catch (EntryValidationException e) {
+            assertThat(e.getMessage(), equalTo("Field 'fields' values must be of type 'string'"));
+            assertThat(e.getEntry().toString(), equalTo(jsonString));
+        }
+    }
 }


### PR DESCRIPTION
Mint should reject register entries which have keys with empty string values.
