### PR TITLE
Throw 500 error if CT server doesn't like our request

### DIFF
--- a/src/main/java/uk/gov/mint/CTException.java
+++ b/src/main/java/uk/gov/mint/CTException.java
@@ -1,19 +1,7 @@
 package uk.gov.mint;
 
 public class CTException extends RuntimeException {
-    private int status;
-
-    public CTException(int status, String reason) {
+    public CTException(String reason) {
         super(reason);
-
-        this.status = status;
-    }
-
-    public int getStatus() {
-        return status;
-    }
-
-    public void setStatus(int status) {
-        this.status = status;
     }
 }

--- a/src/main/java/uk/gov/mint/CTExceptionMapper.java
+++ b/src/main/java/uk/gov/mint/CTExceptionMapper.java
@@ -1,10 +1,16 @@
 package uk.gov.mint;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 public class CTExceptionMapper implements ExceptionMapper<CTException> {
+    private static final Logger LOG = LoggerFactory.getLogger(CTExceptionMapper.class);
+
     public Response toResponse(CTException ex) {
-        return Response.status(ex.getStatus()).entity(ex.getMessage()).type("text/plain").build();
+        LOG.error("Problem talking to CT server: {}", ex.getMessage());
+        return Response.serverError().entity(ex.getMessage()).type("text/plain").build();
     }
 }

--- a/src/main/java/uk/gov/mint/CTHandler.java
+++ b/src/main/java/uk/gov/mint/CTHandler.java
@@ -36,7 +36,7 @@ public class CTHandler implements Loader {
                     .post(Entity.entity(singleEntry, MediaType.APPLICATION_JSON), Response.class);
             try {
                 if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                    throw new CTException(response.getStatus(), response.readEntity(String.class));
+                    throw new CTException(response.readEntity(String.class));
                 }
             } finally {
                 response.close();

--- a/src/test/java/uk/gov/functional/CTFunctionalTest.java
+++ b/src/test/java/uk/gov/functional/CTFunctionalTest.java
@@ -45,7 +45,7 @@ public class CTFunctionalTest {
     private final JerseyClient jerseyClient = authenticatingClient();
 
     @Test
-    public void checkThatErrorsFromCTServerArePropogatedBack() throws Exception {
+    public void clientErrorFromCTServerIndicatesBugInMint() throws Exception {
         stubFor(post(urlEqualTo("/add-json"))
                 .willReturn(aResponse()
                         .withStatus(400)
@@ -53,7 +53,7 @@ public class CTFunctionalTest {
                 ));
 
         Response r =  send("{\"register\":\"ft_mint_test\",\"text\":\"SomeText\"}");
-        assertThat(r.getStatus(), equalTo(400));
+        assertThat(r.getStatus(), equalTo(500));
     }
 
     private Response send(String... payload) {


### PR DESCRIPTION
Previously, if the CT server returned a 400 Bad Request, we would just
return that to the caller.  However on reflection if we are making a
request to the CT server which is malformed in some way, that indicates
that we have a bug in mint that needs to be fixed.  The correct response
in this case is 500 Internal Server Error, to demonstrate that the
problem lies within mint rather than with whoever is submitting
something to mint.
