### PR TITLE
Disable gzip for requests

### DIFF
--- a/src/main/java/uk/gov/MintConfiguration.java
+++ b/src/main/java/uk/gov/MintConfiguration.java
@@ -39,6 +39,10 @@ public class MintConfiguration extends Configuration {
 
     @JsonProperty("jerseyClient")
     public JerseyClientConfiguration getJerseyClientConfiguration() {
+        /* xjson-server can't cope with gzip
+         * https://github.com/google/certificate-transparency/issues/1109
+         */
+        jerseyClientConfiguration.setGzipEnabledForRequests(false);
         return jerseyClientConfiguration;
     }
 


### PR DESCRIPTION
The xjson-server ignores the content-encoding header and gets confused
by a gzip-encoded entity.  Disable it so we avoid that problem.

See also google/certificate-transparency#1109
