### PR TITLE
CanonicalJsonMapper methods should not throw checked exception

### DIFF
--- a/src/main/java/uk/gov/mint/CanonicalJsonMapper.java
+++ b/src/main/java/uk/gov/mint/CanonicalJsonMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.mint;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -17,15 +16,23 @@ public class CanonicalJsonMapper {
         objectMapper.getFactory().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, false);
     }
 
-    public JsonNode readFromBytes(byte[] body) throws IOException {
-        return objectMapper.readValue(body, JsonNode.class);
+    public JsonNode readFromBytes(byte[] body) {
+        try {
+            return objectMapper.readValue(body, JsonNode.class);
+        } catch (IOException e) {
+            return ExceptionUtils.rethrow(e);
+        }
     }
 
-    public byte[] writeToBytes(JsonNode jsonNode) throws JsonProcessingException {
-        // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
-        Object obj = objectMapper.treeToValue(jsonNode, Object.class);
-        // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
-        // our canonical form requires raw unescaped unicode, so we need this version
-        return objectMapper.writeValueAsString(obj).getBytes();
+    public byte[] writeToBytes(JsonNode jsonNode) {
+        try {
+            // Method from http://stackoverflow.com/questions/18952571/jackson-jsonnode-to-string-with-sorted-keys
+            Object obj = objectMapper.treeToValue(jsonNode, Object.class);
+            // for some reason, writeValueAsString(obj).getBytes() doesn't re-escape unicode, but writeValueAsBytes does
+            // our canonical form requires raw unescaped unicode, so we need this version
+            return objectMapper.writeValueAsString(obj).getBytes();
+        } catch (IOException e) {
+            return ExceptionUtils.rethrow(e);
+        }
     }
 }

--- a/src/main/java/uk/gov/mint/LoadHandler.java
+++ b/src/main/java/uk/gov/mint/LoadHandler.java
@@ -22,13 +22,7 @@ public class LoadHandler implements Loader {
     @Override
     public void load(List<JsonNode> entries) {
         List<byte[]> entriesAsBytes = entries.stream()
-                .map(singleEntry -> {
-                    try {
-                        return canonicalJsonMapper.writeToBytes(hashedEntry(singleEntry));
-                    } catch (Exception ex) {
-                        return ExceptionUtils.rethrow(ex);
-                    }
-                })
+                .map(singleEntry -> canonicalJsonMapper.writeToBytes(hashedEntry(singleEntry)))
                 .collect(Collectors.toList());
         entriesUpdateDAO.add(entriesAsBytes);
     }

--- a/src/main/java/uk/gov/mint/ObjectReconstructor.java
+++ b/src/main/java/uk/gov/mint/ObjectReconstructor.java
@@ -16,13 +16,7 @@ public class ObjectReconstructor {
 
     public List<JsonNode> reconstruct(String[] jsonObjectsAsStrings) {
         return Arrays.stream(jsonObjectsAsStrings)
-                .map(e -> {
-                    try {
-                        return canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8));
-                    } catch (Exception ex) {
-                        return ExceptionUtils.rethrow(ex);
-                    }
-                })
+                .map(e -> canonicalJsonMapper.readFromBytes(e.getBytes(StandardCharsets.UTF_8)))
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/mint/ObjectReconstructorTest.java
+++ b/src/test/java/uk/gov/mint/ObjectReconstructorTest.java
@@ -1,20 +1,11 @@
 package uk.gov.mint;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ObjectReconstructorTest {
-
-    @Test(expected = JsonParseException.class)
-    public void handle_throwsJsonParseExceptionWhenTheInputIsNotValidJsonl() {
-        ObjectReconstructor testObj = new ObjectReconstructor();
-        String payload = "{\"register\":\n\"value1\"}";
-        testObj.reconstruct(payload.split("\n"));
-    }
-
     @Test
     public void createsJsonNodeFromValidJson() {
         ObjectReconstructor testObj = new ObjectReconstructor();


### PR DESCRIPTION
It helps while using these methods within lambda function so that there is no need of explicitly handling checked exception.
