### PR TITLE
Must ignore rule

### DIFF
--- a/src/main/java/uk/gov/register/Field.java
+++ b/src/main/java/uk/gov/register/Field.java
@@ -9,7 +9,7 @@ import uk.gov.register.datatype.DatatypeFactory;
 
 import java.util.Optional;
 
-@JsonIgnoreProperties({"phase", "text"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Field {
     final String fieldName;
     final Datatype datatype;

--- a/src/main/java/uk/gov/register/FieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/FieldsConfiguration.java
@@ -48,7 +48,7 @@ public class FieldsConfiguration {
         return fields.stream().filter(f -> Objects.equals(f.fieldName, fieldName)).findFirst().get();
     }
 
-    @JsonIgnoreProperties({"hash", "last-updated"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private static class FieldData {
         @JsonProperty
         Field entry;

--- a/src/main/java/uk/gov/register/Register.java
+++ b/src/main/java/uk/gov/register/Register.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Set;
 
-@JsonIgnoreProperties({"phase", "text", "registry", "copyright"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Register {
     final String registerName;
     final Set<String> fields;

--- a/src/main/java/uk/gov/register/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/RegistersConfiguration.java
@@ -46,7 +46,7 @@ public class RegistersConfiguration {
         return registers.stream().filter(f -> Objects.equals(f.registerName, registerName)).findFirst().get();
     }
 
-    @JsonIgnoreProperties({"hash", "last-updated"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private static class RegisterData {
         @JsonProperty
         Register entry;

--- a/src/main/resources/config/fields.yaml
+++ b/src/main/resources/config/fields.yaml
@@ -1,5 +1,34 @@
 ---
-- hash: "fe06b216567b0561f55f2454d5637293a85c117a"
+- serial-number: 59
+  hash: "ed0fa755a6ef0c5d9b7ea5b57ad3d18347944fd7"
+  entry:
+    cardinality: "1"
+    datatype: "string"
+    field: "territory"
+    phase: "alpha"
+    register: "territory"
+    text: "A territory"
+- serial-number: 58
+  hash: "335f23800af9a4e94e1d58d3feb790a368ad84bb"
+  entry:
+    cardinality: "1"
+    datatype: "string"
+    field: "uk"
+    phase: "alpha"
+    register: "uk"
+    text: "A constituent unit of the United Kingdom of Great Britain and Northern\
+      \ Ireland or a Crown dependency"
+- serial-number: 57
+  hash: "8cf1527a510e3fdf9c4e30a251afa0427f28ac16"
+  entry:
+    cardinality: "1"
+    datatype: "curie"
+    field: "business"
+    phase: "alpha"
+    register: "company"
+    text: "A Limited Company, School or other legal entity that trades."
+- serial-number: 56
+  hash: "fe06b216567b0561f55f2454d5637293a85c117a"
   entry:
     cardinality: "1"
     datatype: "url"
@@ -7,7 +36,8 @@
     phase: "alpha"
     register: ""
     text: "Website for register entry."
-- hash: "e88d65c86392a79e1c9e2058a1d5000ec41aa5e6"
+- serial-number: 55
+  hash: "e88d65c86392a79e1c9e2058a1d5000ec41aa5e6"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -15,7 +45,8 @@
     phase: "alpha"
     register: ""
     text: "The town of an address."
-- hash: "d78d71355334444b89f373422bc081a749a56151"
+- serial-number: 54
+  hash: "d78d71355334444b89f373422bc081a749a56151"
   entry:
     cardinality: "1"
     datatype: "text"
@@ -23,7 +54,8 @@
     phase: "alpha"
     register: ""
     text: "Description of register entry."
-- hash: "d33a9667b032c5e0b7b7a17d67c7752ea2661959"
+- serial-number: 53
+  hash: "d33a9667b032c5e0b7b7a17d67c7752ea2661959"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -31,7 +63,8 @@
     phase: "alpha"
     register: ""
     text: "The number and street name of an address."
-- hash: "784604406a12ac5de4d0c5ea1318e8a982e3b194"
+- serial-number: 52
+  hash: "784604406a12ac5de4d0c5ea1318e8a982e3b194"
   entry:
     cardinality: "1"
     datatype: "datetime"
@@ -39,7 +72,8 @@
     phase: "alpha"
     register: ""
     text: "Start datetime for the applicability of a register entry."
-- hash: "19840647db2398effaad27fc11ab97bbf5834350"
+- serial-number: 51
+  hash: "19840647db2398effaad27fc11ab97bbf5834350"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -47,7 +81,8 @@
     phase: "alpha"
     register: "school"
     text: "A school in the UK."
-- hash: "b8313e492b5ad3a6a6d358fcf9583c04576708b0"
+- serial-number: 50
+  hash: "b8313e492b5ad3a6a6d358fcf9583c04576708b0"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -55,7 +90,8 @@
     phase: "alpha"
     register: ""
     text: "Religious character of school as declared by the school."
-- hash: "9b10698ddcf38a42bd1e76d02255774d68e42430"
+- serial-number: 49
+  hash: "9b10698ddcf38a42bd1e76d02255774d68e42430"
   entry:
     cardinality: "1"
     datatype: "curie"
@@ -63,7 +99,8 @@
     phase: "alpha"
     register: "public-body"
     text: "Body responsible for maintaining one or more registers"
-- hash: "d12f6740958fcf17a6105ff6146b6382f89bd117"
+- serial-number: 48
+  hash: "d12f6740958fcf17a6105ff6146b6382f89bd117"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -71,7 +108,8 @@
     phase: "alpha"
     register: "address"
     text: "Registered address for a company or other legal entity."
-- hash: "6a8e554656804bc7834a9ef6d71b1ba69e94734c"
+- serial-number: 47
+  hash: "6a8e554656804bc7834a9ef6d71b1ba69e94734c"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -79,7 +117,8 @@
     phase: "alpha"
     register: "register"
     text: "A register name."
-- hash: "7a3cd06797be9d957181eec736337ad33902b13d"
+- serial-number: 46
+  hash: "7a3cd06797be9d957181eec736337ad33902b13d"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -87,7 +126,8 @@
     phase: "alpha"
     register: "public-body"
     text: "A UK governmental body."
-- hash: "454559af4e3581afb9e9a84a4ee10b238055f3eb"
+- serial-number: 45
+  hash: "454559af4e3581afb9e9a84a4ee10b238055f3eb"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -95,7 +135,8 @@
     phase: "alpha"
     register: ""
     text: "Type of government body."
-- hash: "09a85dff0c42412c7da25a14e24142aa0be0b2cd"
+- serial-number: 44
+  hash: "09a85dff0c42412c7da25a14e24142aa0be0b2cd"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -103,7 +144,8 @@
     phase: "alpha"
     register: ""
     text: "A building, institution or house name in an address."
-- hash: "6005a1738e6ed2992cd4b0d13b55f1e00bc0ff1a"
+- serial-number: 43
+  hash: "6005a1738e6ed2992cd4b0d13b55f1e00bc0ff1a"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -111,7 +153,8 @@
     phase: "alpha"
     register: "premises"
     text: "A business premises."
-- hash: "15bff6654c66d1e50ba1420984c583900c4678b6"
+- serial-number: 42
+  hash: "15bff6654c66d1e50ba1420984c583900c4678b6"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -119,7 +162,8 @@
     phase: "alpha"
     register: "postcode"
     text: "UK Postcodes."
-- hash: "b9e5bc6a5bff8317c263bc0760654c2e54af3f2a"
+- serial-number: 41
+  hash: "b9e5bc6a5bff8317c263bc0760654c2e54af3f2a"
   entry:
     cardinality: "1"
     datatype: "point"
@@ -127,7 +171,8 @@
     phase: "alpha"
     register: ""
     text: "A geographical location"
-- hash: "8b6921381857dc32b05936a9a16479966cd0cd64"
+- serial-number: 40
+  hash: "8b6921381857dc32b05936a9a16479966cd0cd64"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -135,7 +180,8 @@
     phase: "alpha"
     register: ""
     text: "Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual)."
-- hash: "470298d704a40d052e19e3b8750e7adf4e5f5f11"
+- serial-number: 39
+  hash: "470298d704a40d052e19e3b8750e7adf4e5f5f11"
   entry:
     cardinality: "n"
     datatype: "string"
@@ -143,7 +189,8 @@
     phase: "alpha"
     register: ""
     text: "Parent bodies."
-- hash: "48de2c4bae33ad229e5d87ab54eb8307ff5082c2"
+- serial-number: 38
+  hash: "48de2c4bae33ad229e5d87ab54eb8307ff5082c2"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -151,7 +198,8 @@
     phase: "alpha"
     register: ""
     text: "An owner of government domain"
-- hash: "1b7737fb7cd73cc088f678377ba89f3640e06f72"
+- serial-number: 37
+  hash: "1b7737fb7cd73cc088f678377ba89f3640e06f72"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -159,7 +207,8 @@
     phase: "alpha"
     register: ""
     text: "Official name of country"
-- hash: "874f9835ad48c072d0149dd2a643e2d240d8a154"
+- serial-number: 36
+  hash: "874f9835ad48c072d0149dd2a643e2d240d8a154"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -167,7 +216,8 @@
     phase: "alpha"
     register: ""
     text: "Official colour for a public body."
-- hash: "822891faaad33beea6382f4f533dae8dbf918416"
+- serial-number: 35
+  hash: "822891faaad33beea6382f4f533dae8dbf918416"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -175,7 +225,8 @@
     phase: "alpha"
     register: ""
     text: "Name of field"
-- hash: "14442576d60b23041799631dff97d221403edc67"
+- serial-number: 34
+  hash: "14442576d60b23041799631dff97d221403edc67"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -183,7 +234,8 @@
     phase: "alpha"
     register: ""
     text: "Minimum intake age for pupils at a school."
-- hash: "f0f8aec8bcee5e4cc3c9c8fcf4750b0470a7ac44"
+- serial-number: 33
+  hash: "f0f8aec8bcee5e4cc3c9c8fcf4750b0470a7ac44"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -191,7 +243,8 @@
     phase: "alpha"
     register: ""
     text: "Maximum intake age for pupils at a school."
-- hash: "6e9537ab2cdb6fd5710f2df0d0ecb636f8fadc04"
+- serial-number: 32
+  hash: "6e9537ab2cdb6fd5710f2df0d0ecb636f8fadc04"
   entry:
     cardinality: "1"
     datatype: "curie"
@@ -200,7 +253,8 @@
     register: "location"
     text: "A geographic location found in government data which may be published under\
       \ an open government licence"
-- hash: "c9fc51aa3c1ac7551141f0c23c3ff0cd9f310cf3"
+- serial-number: 31
+  hash: "c9fc51aa3c1ac7551141f0c23c3ff0cd9f310cf3"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -208,7 +262,8 @@
     phase: "alpha"
     register: ""
     text: "The area within a post town."
-- hash: "3c2920b3f74bad5c8674bf9eee69152c7981f7fe"
+- serial-number: 30
+  hash: "3c2920b3f74bad5c8674bf9eee69152c7981f7fe"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -216,7 +271,8 @@
     phase: "alpha"
     register: "local-authority"
     text: "A Local Authority in England, Scotland, Wales or Northern Ireland."
-- hash: "fe44cd6de9a0e438f32381ab69dd8567890171a1"
+- serial-number: 29
+  hash: "fe44cd6de9a0e438f32381ab69dd8567890171a1"
   entry:
     cardinality: "1"
     datatype: "curie"
@@ -224,7 +280,8 @@
     phase: "alpha"
     register: ""
     text: "The organisation conducting an inspection"
-- hash: "453a6c55382911d002d494ab8c2307763f3c2694"
+- serial-number: 28
+  hash: "453a6c55382911d002d494ab8c2307763f3c2694"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -232,7 +289,8 @@
     phase: "alpha"
     register: "industry"
     text: "Standard industrial classification."
-- hash: "77ba22309b042a11942a5c8ee7b4f912658b86b8"
+- serial-number: 27
+  hash: "77ba22309b042a11942a5c8ee7b4f912658b86b8"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -240,7 +298,8 @@
     phase: "alpha"
     register: ""
     text: "Headteacher of school."
-- hash: "d018b43d9e4f5dd7f7bc0ea40f3087733234849d"
+- serial-number: 26
+  hash: "d018b43d9e4f5dd7f7bc0ea40f3087733234849d"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -248,7 +307,8 @@
     phase: "alpha"
     register: "government-domain"
     text: "A domain"
-- hash: "ad41a0b1344addc0d57cde415092424c82786199"
+- serial-number: 25
+  hash: "ad41a0b1344addc0d57cde415092424c82786199"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -256,7 +316,8 @@
     phase: "alpha"
     register: ""
     text: "Gender."
-- hash: "b6a6f32b15f3aa55327b97c4729413f7bf0d321f"
+- serial-number: 24
+  hash: "b6a6f32b15f3aa55327b97c4729413f7bf0d321f"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -264,7 +325,8 @@
     phase: "alpha"
     register: "food-premises"
     text: "A premises which serves or processes food."
-- hash: "0ecd7597b5cfdfba4375319dddd6df5bd3df51d1"
+- serial-number: 23
+  hash: "0ecd7597b5cfdfba4375319dddd6df5bd3df51d1"
   entry:
     cardinality: "n"
     datatype: "string"
@@ -272,7 +334,8 @@
     phase: "alpha"
     register: "food-premises-type"
     text: "A set of food premises types."
-- hash: "85cbb8d09f3a11f58d61ca035c2b5f27b5630f20"
+- serial-number: 22
+  hash: "85cbb8d09f3a11f58d61ca035c2b5f27b5630f20"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -280,7 +343,8 @@
     phase: "alpha"
     register: "food-premises-type"
     text: "The type of food premises."
-- hash: "84e0813c921fda06caa57c54f1580ecfc1f3d277"
+- serial-number: 21
+  hash: "84e0813c921fda06caa57c54f1580ecfc1f3d277"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -288,7 +352,8 @@
     phase: "alpha"
     register: ""
     text: "A score for the rating of a food premises."
-- hash: "b62ceb84724861af1be54879c378e75525feffd0"
+- serial-number: 20
+  hash: "b62ceb84724861af1be54879c378e75525feffd0"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -297,7 +362,8 @@
     register: ""
     text: "A rating of the food hygiene served at a premises, 0-5 with 5 meaning 'very\
       \ good'."
-- hash: "7a00b5873b8bd8b1f70b48d0f7451433eed57966"
+- serial-number: 19
+  hash: "7a00b5873b8bd8b1f70b48d0f7451433eed57966"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -307,7 +373,8 @@
     text: "Level of compliance with structural requirements including cleanliness,\
       \ layout, condition of structure, lighting, ventilation, facilities etc. Lower\
       \ scores are better."
-- hash: "81c1d21cc9a90b9bf33cb0388de6880b2311dd23"
+- serial-number: 18
+  hash: "81c1d21cc9a90b9bf33cb0388de6880b2311dd23"
   entry:
     cardinality: "1"
     datatype: "text"
@@ -318,7 +385,8 @@
       \ have taken to improve hygiene standards after a food hygiene rating has been\
       \ given or to say if there were particular circumstances at the time of the\
       \ inspection that might have affected the rating."
-- hash: "cb4be5354f791a1ca43f4c90b0c57ba53beb77ad"
+- serial-number: 17
+  hash: "cb4be5354f791a1ca43f4c90b0c57ba53beb77ad"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -328,7 +396,8 @@
     text: "Level of compliance with food hygiene and safety procedures including food\
       \ handling practices and procedures, and temperature control. Lower scores are\
       \ better."
-- hash: "a9736050688a1094c056bb7dc4a606850977fbb5"
+- serial-number: 16
+  hash: "a9736050688a1094c056bb7dc4a606850977fbb5"
   entry:
     cardinality: "1"
     datatype: "integer"
@@ -336,7 +405,8 @@
     phase: "alpha"
     register: ""
     text: "Level of confidence with management. Lower scores are better."
-- hash: "1259bc57e03cbbf8e59abdfe2645c7b35b41ec76"
+- serial-number: 15
+  hash: "1259bc57e03cbbf8e59abdfe2645c7b35b41ec76"
   entry:
     cardinality: "n"
     datatype: "string"
@@ -344,7 +414,8 @@
     phase: "alpha"
     register: "field"
     text: "Set of field names."
-- hash: "e234a891b49943c8b0f44a4568db84e853d50410"
+- serial-number: 14
+  hash: "e234a891b49943c8b0f44a4568db84e853d50410"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -352,7 +423,8 @@
     phase: "alpha"
     register: "field"
     text: "Field name of register entry."
-- hash: "237153282f3a2c33d904d65bf02a065b92688e91"
+- serial-number: 13
+  hash: "237153282f3a2c33d904d65bf02a065b92688e91"
   entry:
     cardinality: "1"
     datatype: "datetime"
@@ -360,7 +432,8 @@
     phase: "alpha"
     register: ""
     text: "End datetime for the applicability of a register entry."
-- hash: "6b6dba22e7e8e9103924059a8b77d03f94a1fbdd"
+- serial-number: 12
+  hash: "6b6dba22e7e8e9103924059a8b77d03f94a1fbdd"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -368,7 +441,8 @@
     phase: "alpha"
     register: ""
     text: "An email address for contact."
-- hash: "dd22f2db37c73d2dc1d99d22c0282cfec14308c4"
+- serial-number: 11
+  hash: "dd22f2db37c73d2dc1d99d22c0282cfec14308c4"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -376,7 +450,8 @@
     phase: "alpha"
     register: "datatype"
     text: "The data type for constraining a field value."
-- hash: "0e00ce00a433bc68b9c30338fd2c2d71c68f7f08"
+- serial-number: 10
+  hash: "0e00ce00a433bc68b9c30338fd2c2d71c68f7f08"
   entry:
     cardinality: "1"
     datatype: "url"
@@ -384,7 +459,8 @@
     phase: "alpha"
     register: ""
     text: "Official crest for a government body."
-- hash: "12ee27755b0118bc391b18d804ec21abb51a9479"
+- serial-number: 9
+  hash: "12ee27755b0118bc391b18d804ec21abb51a9479"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -392,7 +468,8 @@
     phase: "alpha"
     register: "country"
     text: "ISO 3166-2 two letter code for a country."
-- hash: "15000add6b8a0625abd14fa3f5c39dc54abe92aa"
+- serial-number: 8
+  hash: "15000add6b8a0625abd14fa3f5c39dc54abe92aa"
   entry:
     cardinality: "1"
     datatype: "text"
@@ -400,7 +477,8 @@
     phase: "alpha"
     register: ""
     text: "Copyright for the data in the register."
-- hash: "15955914ceb90a824c2fe6e2432455814169268a"
+- serial-number: 7
+  hash: "15955914ceb90a824c2fe6e2432455814169268a"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -408,7 +486,8 @@
     phase: "alpha"
     register: "company"
     text: "A UK registered company."
-- hash: "dace043fab243727edac7789d213df708dd7352f"
+- serial-number: 6
+  hash: "dace043fab243727edac7789d213df708dd7352f"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -416,7 +495,8 @@
     phase: "alpha"
     register: ""
     text: "The status of a UK company."
-- hash: "aca249580d9a92023b207f3c74ea54b8e038e67e"
+- serial-number: 5
+  hash: "aca249580d9a92023b207f3c74ea54b8e038e67e"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -424,7 +504,8 @@
     phase: "alpha"
     register: ""
     text: "Name for the citzens of a country."
-- hash: "4de105d95a62b4cbcbaecbbc592ba52a745acb51"
+- serial-number: 4
+  hash: "4de105d95a62b4cbcbaecbbc592ba52a745acb51"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -432,15 +513,8 @@
     phase: "alpha"
     register: ""
     text: "Number of elements of the set (1 or n)."
-- hash: "380c9752d9b4648a77df10894414b64b97277eb4"
-  entry:
-    cardinality: "1"
-    datatype: "curie"
-    field: "business"
-    phase: "alpha"
-    register: ""
-    text: "A Limited Company, School or other legal entity that trades."
-- hash: "bf4172b99e36c850d3ad391e90462107d9603980"
+- serial-number: 2
+  hash: "bf4172b99e36c850d3ad391e90462107d9603980"
   entry:
     cardinality: "1"
     datatype: "string"
@@ -448,7 +522,8 @@
     phase: "alpha"
     register: ""
     text: "The administrative area of an address."
-- hash: "91fa9952f411c9f4cd2067cbbd233b3d51449fdc"
+- serial-number: 1
+  hash: "91fa9952f411c9f4cd2067cbbd233b3d51449fdc"
   entry:
     cardinality: "1"
     datatype: "string"

--- a/src/main/resources/config/registers.yaml
+++ b/src/main/resources/config/registers.yaml
@@ -1,5 +1,64 @@
 ---
-- hash: "401c9ad49aed68eed0083341b13c8e8d4a09c0dd"
+- serial-number: 23
+  hash: "247cf017d1b91ca8e0cd3abb60712224c6fa2b03"
+  entry:
+    fields:
+    - "country"
+    - "name"
+    - "official-name"
+    - "citizen-names"
+    - "start-date"
+    - "end-date"
+    phase: "alpha"
+    register: "country"
+    registry: "foreign-commonwealth-office"
+    text: "British English-language names and descriptive terms for countries"
+- serial-number: 22
+  hash: "2bbd8b62163e2b6e42d8fb59742f33117f54ec02"
+  entry:
+    fields:
+    - "uk"
+    - "name"
+    - "official-name"
+    - "start-date"
+    - "end-date"
+    - "citizen-names"
+    phase: "alpha"
+    register: "uk"
+    registry: "cabinet-office"
+    text: "UK and Crown dependencies"
+- serial-number: 21
+  hash: "77ba68854b715e6a764c5c53c07611c25614efc0"
+  entry:
+    fields:
+    - "territory"
+    - "name"
+    - "official-name"
+    - "start-date"
+    - "end-date"
+    - "citizen-names"
+    phase: "alpha"
+    register: "territory"
+    registry: "foreign-commonwealth-office"
+    text: "British English-language names and descriptive terms for territories"
+- serial-number: 20
+  hash: "bb9e892b5b04d171f1d8af9f449d46b2d4b8940e"
+  entry:
+    fields:
+    - "food-premises"
+    - "name"
+    - "business"
+    - "food-premises-types"
+    - "local-authority"
+    - "premises"
+    - "start-date"
+    - "end-date"
+    phase: "alpha"
+    register: "food-premises"
+    registry: "food-standards-agency"
+    text: "Premises which prepare and serve food"
+- serial-number: 18
+  hash: "401c9ad49aed68eed0083341b13c8e8d4a09c0dd"
   entry:
     fields:
     - "school"
@@ -17,7 +76,8 @@
     register: "school"
     registry: "department-for-education"
     text: "Primary, secondary and special needs schools in England and Wales"
-- hash: "f5902bb26bceb5fa4368e2be5db65c4ba139ed41"
+- serial-number: 17
+  hash: "f5902bb26bceb5fa4368e2be5db65c4ba139ed41"
   entry:
     fields:
     - "registry"
@@ -25,7 +85,8 @@
     register: "registry"
     registry: "cabinet-office"
     text: "Bodies responsible for the maintainance of one or more registers"
-- hash: "b51e90b4e68186503c8cb1b25ba672ef5c170bb0"
+- serial-number: 16
+  hash: "b51e90b4e68186503c8cb1b25ba672ef5c170bb0"
   entry:
     fields:
     - "register"
@@ -38,7 +99,8 @@
     register: "register"
     registry: "cabinet-office"
     text: "Registers maintained by HM Government"
-- hash: "701b682581fd06b346fb8d2126c378ee2cf369fc"
+- serial-number: 15
+  hash: "701b682581fd06b346fb8d2126c378ee2cf369fc"
   entry:
     fields:
     - "public-body"
@@ -53,7 +115,8 @@
     register: "public-body"
     registry: "cabinet-office"
     text: "Ministerial Departments and agencies sponsored by HM Government"
-- hash: "ac5f75e97b1e254c928c198501b49ceab901fb66"
+- serial-number: 14
+  hash: "ac5f75e97b1e254c928c198501b49ceab901fb66"
   entry:
     fields:
     - "premises"
@@ -64,7 +127,8 @@
     register: "premises"
     registry: "valuation-office-agency"
     text: "Commercial properties eligable for business rates in England and Wales"
-- hash: "5093cb53ea680811db8a581e195b2d110d1ad134"
+- serial-number: 13
+  hash: "5093cb53ea680811db8a581e195b2d110d1ad134"
   entry:
     copyright: "Contains National Statistics data © [Crown copyright and database\
       \ right 2013](http://www.nationalarchives.gov.uk/doc/open-government-licence/),\
@@ -77,7 +141,8 @@
     register: "postcode"
     registry: "office-for-national-statistics"
     text: "Postal codes which may appear in a UK address"
-- hash: "daa3c58b45aab258addeb6f4a3abde7a4e090522"
+- serial-number: 12
+  hash: "daa3c58b45aab258addeb6f4a3abde7a4e090522"
   entry:
     fields:
     - "location"
@@ -87,7 +152,8 @@
     registry: "cabinet-office"
     text: "Geographic locations of places found in government data which may be published\
       \ under an open government licence"
-- hash: "a3ffa841bf05ca17c5daad6c6386a9feef134d53"
+- serial-number: 11
+  hash: "a3ffa841bf05ca17c5daad6c6386a9feef134d53"
   entry:
     fields:
     - "local-authority"
@@ -101,7 +167,8 @@
     register: "local-authority"
     registry: "department-for-communities-and-local-government"
     text: "Local authorities in England"
-- hash: "688d38ec38e1546936c893ead2b862b8447736ed"
+- serial-number: 10
+  hash: "688d38ec38e1546936c893ead2b862b8447736ed"
   entry:
     fields:
     - "industry"
@@ -114,7 +181,8 @@
     text: "Standard Industry Codes (SIC) used to classify business establishments\
       \ and other standard units by the type of economic activity in which they are\
       \ engaged"
-- hash: "464f4889f731a40ab1769a396b570ffa3ec0d74c"
+- serial-number: 9
+  hash: "464f4889f731a40ab1769a396b570ffa3ec0d74c"
   entry:
     fields:
     - "government-domain"
@@ -124,20 +192,8 @@
     register: "government-domain"
     registry: "government-digital-service"
     text: "Internet domain names used by HM Government"
-- hash: "fef4f20d2288f031d77e03b50393d6ec92a6cab7"
-  entry:
-    fields:
-    - "food-premises"
-    - "name"
-    - "business"
-    - "food-premises-types"
-    - "start-date"
-    - "end-date"
-    phase: "alpha"
-    register: "food-premises"
-    registry: "food-standards-agency"
-    text: "Premises which prepare and serve food"
-- hash: "8425ee369e87e8dbeb217af0d7217251ba32ab1c"
+- serial-number: 7
+  hash: "8425ee369e87e8dbeb217af0d7217251ba32ab1c"
   entry:
     fields:
     - "food-premises-type"
@@ -146,7 +202,8 @@
     register: "food-premises-type"
     registry: "food-standards-agency"
     text: "Types of premises which prepare and serve food"
-- hash: "9db376033a0136dac33746cc30154978e5496828"
+- serial-number: 6
+  hash: "9db376033a0136dac33746cc30154978e5496828"
   entry:
     fields:
     - "food-premises-rating"
@@ -164,7 +221,8 @@
     register: "food-premises-rating"
     registry: "food-standards-agency"
     text: "Food hygiene inspection ratings"
-- hash: "572bef0ffc666e39421fda821e2f899bb4061dd7"
+- serial-number: 5
+  hash: "572bef0ffc666e39421fda821e2f899bb4061dd7"
   entry:
     fields:
     - "field"
@@ -177,7 +235,8 @@
     register: "field"
     registry: "cabinet-office"
     text: "Field names which may appear in a register"
-- hash: "ab933e49accfac1bf4b57752bcce5843e54f5f44"
+- serial-number: 4
+  hash: "ab933e49accfac1bf4b57752bcce5843e54f5f44"
   entry:
     fields:
     - "datatype"
@@ -188,21 +247,8 @@
     registry: "cabinet-office"
     text: "Datatypes constraining values used by register fields and idenitifying\
       \ ways in which it may be encoded a representation"
-- hash: "92fdfdad3ffa376074d07ae27344bba7ba3f730a"
-  entry:
-    fields:
-    - "country"
-    - "name"
-    - "official-name"
-    - "citizen-names"
-    - "start-date"
-    - "end-date"
-    - "text"
-    phase: "alpha"
-    register: "country"
-    registry: "foreign-commonwealth-office"
-    text: "Countries of the world recognised by the UK"
-- hash: "7bfde48aa3d06c682dbfe251ae2e1bf4c5415133"
+- serial-number: 2
+  hash: "7bfde48aa3d06c682dbfe251ae2e1bf4c5415133"
   entry:
     fields:
     - "company"
@@ -216,7 +262,8 @@
     register: "company"
     registry: "companies-house"
     text: "Companies in England and Wales"
-- hash: "d7863fe1f7237401b12b84a61aaab46b74f26ed8"
+- serial-number: 1
+  hash: "d7863fe1f7237401b12b84a61aaab46b74f26ed8"
   entry:
     copyright: "Contains Ordnance Survey data © Crown copyright & database right 2015\
       \ Contains Royal Mail data © Royal Mail copyright & database right 2015"


### PR DESCRIPTION
Register consumers must be [forwards-compatible](http://openregister.github.io/specification/#forwards-compatibility).  As part of this,
they must implement the must-ignore rule.  The best description I have
seen of this rule comes from the [I-JSON RFC](https://tools.ietf.org/html/rfc7493#section-4.2):

```
It is frequently the case that changes to protocols are required
after they have been put in production.  Protocols that allow the
introduction of new protocol elements in a way that does not disrupt
the operation of existing software have proven advantageous in
practice.

This can be referred to as a "Must-Ignore" policy, meaning that when
an implementation encounters a protocol element that it does not
recognize, it should treat the rest of the protocol transaction as if
the new element simply did not appear, and in particular, the
implementation MUST NOT treat this as an error condition.  The
converse "Must-Understand" policy does not tolerate the introduction
of new protocol elements, and while this has proven necessary in
certain protocol designs, in general it has been found to be overly
restrictive and brittle.

A good way to support the use of Must-Ignore in I-JSON protocol
designs is to require that top-level protocol elements must be JSON
objects, and to specify that members whose names are unrecognized
MUST be ignored.
```

Prior to this commit, we were not forwards-compatible against the
introduction of new fields in the register register or the field
register; we also could not understand the `serial-number` key in the
entry structure.

This PR also bumps the yaml files to the latest alpha files directly downloaded from the registers, to confirm that we can use them correctly.
