### PR TITLE
Remove usage of sequence for entry_number in entry table

### DIFF
--- a/src/main/java/uk/gov/mint/Entry.java
+++ b/src/main/java/uk/gov/mint/Entry.java
@@ -1,0 +1,41 @@
+package uk.gov.mint;
+
+
+public class Entry {
+    private final int entry_number;
+    private final String sha256hex;
+
+    public Entry(int entry_number, String sha256hex) {
+        this.entry_number = entry_number;
+        this.sha256hex = sha256hex;
+    }
+
+    @SuppressWarnings("unused, used from DAO")
+    public int getEntry_number() {
+        return entry_number;
+    }
+
+    @SuppressWarnings("unused, used from DAO")
+    public String getSha256hex() {
+        return sha256hex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Entry entry = (Entry) o;
+
+        if (entry_number != entry.entry_number) return false;
+        return sha256hex.equals(entry.sha256hex);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entry_number;
+        result = 31 * result + sha256hex.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/uk/gov/store/EntryDAO.java
+++ b/src/main/java/uk/gov/store/EntryDAO.java
@@ -1,14 +1,20 @@
 package uk.gov.store;
 
 import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import uk.gov.mint.Entry;
 
+@UseStringTemplate3StatementLocator("/sql/entry.sql")
 interface EntryDAO {
-    @SqlUpdate(
-            "create table if not exists entry (entry_number serial primary key, sha256hex varchar, timestamp timestamp default (now() at time zone 'utc'));" +
-                    "alter table entry alter column timestamp set default (now() at time zone 'utc');"
-    )
+    @SqlUpdate
     void ensureSchema();
 
-    @SqlBatch("insert into entry(sha256hex) values(:sha256hex)")
-    void insertInBatch(@Bind("sha256hex") Iterable<String> entries);
+    @SqlBatch("insert into entry(entry_number, sha256hex) values(:entry_number, :sha256hex)")
+    void insertInBatch(@BindBean Iterable<Entry> entries);
+
+    @SqlQuery("select value from current_entry_number")
+    int currentEntryNumber();
+
+    @SqlUpdate("update current_entry_number set value=:entry_number")
+    void setEntryNumber(@Bind("entry_number") int currentEntryNumber);
 }

--- a/src/main/resources/sql/entry.sql
+++ b/src/main/resources/sql/entry.sql
@@ -1,0 +1,22 @@
+group EntryDAO;
+
+ensureSchema() ::= <<
+   create table if not exists entry (entry_number serial primary key, sha256hex varchar, timestamp timestamp default (now() at time zone 'utc'));
+
+   alter table entry alter column timestamp set default (now() at time zone 'utc');
+
+   create table if not exists current_entry_number(value integer not null);
+
+   insert into current_entry_number(value)
+        select (
+            select case
+                when (select max(entry_number) from entry) is null then 0
+                else (select max(entry_number) from entry)
+            end as t
+        )
+        where not exists (
+            select 1 from current_entry_number
+        );
+
+   alter table entry alter column entry_number drop default;
+>>

--- a/src/test/java/uk/gov/functional/PGFunctionalTest.java
+++ b/src/test/java/uk/gov/functional/PGFunctionalTest.java
@@ -15,6 +15,7 @@ import org.junit.rules.TestRule;
 import uk.gov.MintApplication;
 import uk.gov.functional.db.TestDBItem;
 import uk.gov.mint.CanonicalJsonMapper;
+import uk.gov.mint.Entry;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -52,8 +53,8 @@ public class PGFunctionalTest {
         assertThat(storedItem.contents, equalTo(inputItem.getBytes()));
         assertThat(storedItem.sha256hex, equalTo(DigestUtils.sha256Hex(inputItem.getBytes())));
 
-        String hex = testEntryDAO.getAllHex().get(0);
-        assertThat(hex, equalTo(storedItem.sha256hex));
+        Entry entry = testEntryDAO.getAllEntries().get(0);
+        assertThat(entry, equalTo(new Entry(1, storedItem.sha256hex)));
     }
 
     @Test
@@ -68,10 +69,10 @@ public class PGFunctionalTest {
         String canonicalItem1 = new String(canonicalJsonMapper.writeToBytes(canonicalJsonMapper.readFromBytes(item1.getBytes())));
         String canonicalItem2 = new String(canonicalJsonMapper.writeToBytes(canonicalJsonMapper.readFromBytes(item2.getBytes())));
 
-        List<String> entries = testEntryDAO.getAllHex();
+        List<Entry> entries = testEntryDAO.getAllEntries();
         assertThat(entries.size(), equalTo(2));
-        assertThat(entries.get(0), equalTo(DigestUtils.sha256Hex(canonicalItem1)));
-        assertThat(entries.get(1), equalTo(DigestUtils.sha256Hex(canonicalItem2)));
+        assertThat(entries.get(0), equalTo(new Entry(1, DigestUtils.sha256Hex(canonicalItem1))));
+        assertThat(entries.get(1), equalTo(new Entry(2, DigestUtils.sha256Hex(canonicalItem2))));
 
         List<TestDBItem> items = testItemDAO.getItems();
         assertThat(items.size(), equalTo(2));
@@ -94,10 +95,10 @@ public class PGFunctionalTest {
 
         String canonicalItem = new String(canonicalJsonMapper.writeToBytes(canonicalJsonMapper.readFromBytes(item1.getBytes())));
 
-        List<String> entries = testEntryDAO.getAllHex();
+        List<Entry> entries = testEntryDAO.getAllEntries();
         assertThat(entries.size(), equalTo(2));
-        assertThat(entries.get(0), equalTo(DigestUtils.sha256Hex(canonicalItem)));
-        assertThat(entries.get(1), equalTo(DigestUtils.sha256Hex(canonicalItem)));
+        assertThat(entries.get(0), equalTo(new Entry(1, DigestUtils.sha256Hex(canonicalItem))));
+        assertThat(entries.get(1), equalTo(new Entry(2, DigestUtils.sha256Hex(canonicalItem))));
 
         List<TestDBItem> items = testItemDAO.getItems();
         assertThat(items.size(), equalTo(1));

--- a/src/test/java/uk/gov/functional/db/TestEntryDAO.java
+++ b/src/test/java/uk/gov/functional/db/TestEntryDAO.java
@@ -1,14 +1,29 @@
 package uk.gov.functional.db;
 
+import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.mint.Entry;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 
 public interface TestEntryDAO {
-    @SqlUpdate("drop table if exists entry")
+    @SqlUpdate("drop table if exists entry;" +
+            "drop table if exists current_entry_number")
     void dropTable();
 
-    @SqlQuery("select sha256hex from entry")
-    List<String> getAllHex();
+    @RegisterMapper(EntryMapper.class)
+    @SqlQuery("select entry_number,sha256hex from entry")
+    List<Entry> getAllEntries();
+
+    class EntryMapper implements ResultSetMapper<Entry> {
+        @Override
+        public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+            return new Entry(r.getInt("entry_number"), r.getString("sha256hex"));
+        }
+    }
 }


### PR DESCRIPTION
   We are loading data in transaction so there are chances that we might have gaps in between entry numbers.

   Currently we assume that there is no gap in between entry number so if it happens there can be unwanted bugs.

   The changes in PR removes the usage of sequence and use our own table to keep the last entry number.
